### PR TITLE
New 'config' app command which allows users to add/remove/display their ...

### DIFF
--- a/lib/ModelSEED/App/mseed/Command/config.pm
+++ b/lib/ModelSEED/App/mseed/Command/config.pm
@@ -1,0 +1,110 @@
+package ModelSEED::App::mseed::Command::config;
+
+use ModelSEED::Configuration;
+
+use base 'App::Cmd::Command';
+
+sub abstract { "Configure the ModelSEED environment" }
+sub usage_desc { "ms config key=value" }
+
+sub opt_spec {
+    return (
+        ["list|l", "List the values for the given variables"],
+        ["remove|r", "Remove the given variables."]
+    );
+}
+
+sub execute {
+    my ($self, $opts, $args) = @_;
+
+    my $config = ModelSEED::Configuration->new();
+    my $pos_user_opts = $config->_possible_user_options();
+    my $user_opts = $config->user_options();
+
+    if ($opts->{list} && $opts->{remove}) {
+        print STDERR "Cannot specify both 'list' and 'remove' options.\n";
+        exit;
+    } elsif ($opts->{list} || $opts->{remove}) {
+        # make sure the variables exist in user_options
+        foreach my $arg (@$args) {
+            unless (exists($pos_user_opts->{$arg})) {
+                print STDERR "Error, unknown option: '$arg'.\n";
+                exit;
+            }
+        }
+
+        # now process
+        if ($opts->{list}) {
+            if (scalar @$args == 0) {
+                # list all
+                foreach my $opt (sort keys %$user_opts) {
+                    my $val = $user_opts->{$opt};
+                    print "$opt: '" . $val . "'";
+                    if ($val eq $pos_user_opts->{$opt} && $val ne "") {
+                        print " (default)";
+                    }
+                    print "\n";
+                }
+            } else {
+                # list specific
+                foreach my $arg (@$args) {
+                    my $val = $user_opts->{$arg};
+                    print "$arg: '" . $val . "'";
+                    if ($val eq $pos_user_opts->{$arg} && $val ne "") {
+                        print " (default)";
+                    }
+                    print "\n";
+                }
+            }
+        } else {
+            if (scalar @$args == 0) {
+                print STDERR "Error, no options specified.\n";
+                exit;
+            } else {
+                foreach my $arg (@$args) {
+                    if (defined($pos_user_opts->{$arg})) {
+                        $user_opts->{$arg} = $pos_user_opts->{$arg};
+                    } else {
+                        delete $user_opts->{$arg};
+                    }
+                }
+            }
+
+            $config->save();
+        }
+    } else {
+        # trying to set option(s)
+        if (scalar @$args == 0) {
+            # print usage
+            print "Usage: ms config [-i|-r] OPTION[=value]\n";
+            print "  e.g. ms config ERROR_DIR=/home/ms/errors\n";
+            print "       ms config -r ERROR_DIR\n";
+            exit;
+        }
+
+        # make sure all options exist and are valid
+        my $vars = [];
+        foreach my $arg (@$args) {
+            my ($var, $val) = split('=', $arg);
+            unless (defined($var) && defined($val)) {
+                print STDERR "Error, incorrect option usage (syntax: OPTION=value).\n";
+                exit;
+            }
+
+            unless (exists($pos_user_opts->{$var})) {
+                print STDERR "Error, unknown option: '$var'.\n";
+                exit;
+            }
+            push(@$vars, [$var, $val]);
+        }
+
+        # set the options
+        foreach my $var (@$vars) {
+            $user_opts->{$var->[0]} = $var->[1];
+        }
+
+        $config->save();
+    }
+}
+
+1;

--- a/lib/ModelSEED/App/mseed/Command/login.pm
+++ b/lib/ModelSEED/App/mseed/Command/login.pm
@@ -9,8 +9,6 @@ use Class::Autouse qw(
 );
 use base 'App::Cmd::Command';
 
-use Data::Dumper;
-
 sub abstract { "Login as a user" }
 sub usage { "%c COMMAND [username]" }
 sub validate_args {

--- a/lib/ModelSEED/Configuration.pm
+++ b/lib/ModelSEED/Configuration.pm
@@ -87,9 +87,28 @@ has JSON => (
     init_arg => undef
 );
 
+# possible user configuration variables with their default options
+# set to undef to make it optional
+sub _possible_user_options {
+    return {
+        ERROR_DIR => $ENV{HOME} . '/.modelseed_error',
+        MFATK_CACHE => '/tmp', # TODO: this will fail on windows, figure out better way to handle tmp
+        MFATK_BIN => undef,
+        CPLEX_LICENCE => undef
+    }
+}
+
+
+sub user_options {
+    my ($self) = @_;
+    return $self->config->{user_options};
+}
+
 sub _buildConfig {
     my ($self) = @_;
-    my $default = { error_dir => $ENV{HOME} . "/.modelseed_error" };
+    my $default = {
+        user_options => $self->_possible_user_options
+    };
     if (-f $self->filename) {
         local $/;
         open(my $fh, "<", $self->filename) || die "$!";


### PR DESCRIPTION
...current MS configuration options. Changed Configuration.pm to reflect this.
- Removed Data::Dumper from login.pm
- Created ms config command which uses this syntax:
  ms config MFATK_BIN=/home/paul/bin    # add/change option, can add multiple at a time
  ms config -l                                            # display current options
  ms config -l MFATK_BIN                         # display one (or more) options
  ms config -r MFATK_BIN                         # remove option, can remove multiple at a time
- Changed Configuration.pm to distinguish user options from internal options (stores, users, etc).
  - User options are stored in a {user_options} hash, but should be accessed via $config->user_options example:
    my $config = ModelSEED::Configuration->new();
    my $options = $config->user_options();
    my $mfa_bin = $options->{MFATK_BIN};
- New user options should be set in Configuration.pm in the _possible_user_options subroutine
