### PR TITLE
Draft of structured exceptions and usage in CLI

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -20,6 +20,7 @@ my $builder = Module::Build->new(
         "Data::UUID" => 0,
         "DateTime" => 0,
         "Devel::Size" => 0,
+        "Exception::Class" => 0,
         "File::Copy::Recursive" => 0,
         "HTTP::Message" => 0,
         "JSON::XS" => 0,

--- a/bin/bio
+++ b/bin/bio
@@ -1,3 +1,14 @@
 #!/usr/bin/env perl
 use ModelSEED::App::bio;
-ModelSEED::App::bio->run;
+use ModelSEED::Exceptions;
+use Try::Tiny;
+try {
+    ModelSEED::App::bio->run; 
+} catch {
+    local $@ = $_;
+    if ( my $e = Exception::Class->caught('ModelSEED::Exception::CLI') ) {
+        warn $e->cli_error_text();
+    } else {
+        warn $@;
+    }
+};

--- a/bin/genome
+++ b/bin/genome
@@ -1,3 +1,14 @@
 #!/usr/bin/env perl
 use ModelSEED::App::genome;
-ModelSEED::App::genome->run;
+use ModelSEED::Exceptions;
+use Try::Tiny;
+try {
+    ModelSEED::App::genome->run; 
+} catch {
+    local $@ = $_;
+    if ( my $e = Exception::Class->caught('ModelSEED::Exception::CLI') ) {
+        warn $e->cli_error_text();
+    } else {
+        warn $@;
+    }
+};

--- a/bin/mapping
+++ b/bin/mapping
@@ -1,3 +1,14 @@
 #!/usr/bin/env perl
 use ModelSEED::App::mapping;
-ModelSEED::App::mapping->run;
+use ModelSEED::Exceptions;
+use Try::Tiny;
+try {
+    ModelSEED::App::mapping->run; 
+} catch {
+    local $@ = $_;
+    if ( my $e = Exception::Class->caught('ModelSEED::Exception::CLI') ) {
+        warn $e->cli_error_text();
+    } else {
+        warn $@;
+    }
+};

--- a/bin/model
+++ b/bin/model
@@ -1,3 +1,14 @@
 #!/usr/bin/env perl
 use ModelSEED::App::model;
-ModelSEED::App::model->run;
+use ModelSEED::Exceptions;
+use Try::Tiny;
+try {
+    ModelSEED::App::model->run; 
+} catch {
+    local $@ = $_;
+    if ( my $e = Exception::Class->caught('ModelSEED::Exception::CLI') ) {
+        warn $e->cli_error_text();
+    } else {
+        warn $@;
+    }
+};

--- a/bin/ms
+++ b/bin/ms
@@ -1,3 +1,14 @@
 #!/usr/bin/env perl
 use ModelSEED::App::mseed;
-ModelSEED::App::mseed->run;
+use ModelSEED::Exceptions;
+use Try::Tiny;
+try {
+    ModelSEED::App::mseed->run; 
+} catch {
+    local $@ = $_;
+    if ( my $e = Exception::Class->caught('ModelSEED::Exception::CLI') ) {
+        warn $e->cli_error_text();
+    } else {
+        warn $@;
+    }
+};

--- a/bin/stores
+++ b/bin/stores
@@ -1,3 +1,13 @@
 #!/usr/bin/env perl
 use ModelSEED::App::stores;
-ModelSEED::App::stores->run;
+use Try::Tiny;
+try {
+    ModelSEED::App::stores->run; 
+} catch {
+    local $@ = $_;
+    if ( my $e = Exception::Class->caught('ModelSEED::Exception::CLI') ) {
+        warn $e->cli_error_text();
+    } else {
+        warn $@;
+    }
+};

--- a/lib/ModelSEED/Configuration.pm
+++ b/lib/ModelSEED/Configuration.pm
@@ -63,6 +63,7 @@ use JSON qw(encode_json decode_json);
 use Try::Tiny;
 use File::Path qw(mkpath);
 use File::Basename qw(dirname);
+use autodie;
 
 has filename => (
     is       => 'rw',
@@ -111,7 +112,7 @@ sub _buildConfig {
     };
     if (-f $self->filename) {
         local $/;
-        open(my $fh, "<", $self->filename) || die "$!";
+        open(my $fh, "<", $self->filename);
         my $text = <$fh>;
         close($fh);
         my $json;
@@ -139,8 +140,7 @@ sub _buildFilename {
 
 sub save {
     my ($self) = @_;
-    open(my $fh, ">", $self->filename) ||
-        die "Error saving " . $self->filename . ", $@";
+    open(my $fh, ">", $self->filename);
     print $fh $self->JSON->encode($self->config);
     close($fh);
 }

--- a/lib/ModelSEED/Exceptions.pm
+++ b/lib/ModelSEED/Exceptions.pm
@@ -1,0 +1,67 @@
+########################################################################
+# ModelSEED::Exceptions - Object Oriented Exceptions for ModelSEEd
+# Authors: Christopher Henry, Scott Devoid, Paul Frybarger
+# Contact email: chenry@mcs.anl.gov
+# Development location:
+#   Mathematics and Computer Science Division, Argonne National Lab;
+#   Computation Institute, University of Chicago
+#
+# Date of module creation: 2012-08-14
+########################################################################
+package ModelSEED::Exceptions;
+my $NoDatabase = <<ND;
+Unable to construct a database connection.
+If you are using the command line functions,
+configure a database with the "stores" command.
+
+\$ stores help
+ND
+
+use Exception::Class (
+    ModelSEED::Exception::CLI => {
+        description => "Base class for exceptions that support cli_error_text",
+    },
+    ModelSEED::Exception::Database => {
+        isa => "ModelSEED::Exception::CLI",
+        description => "Exception with ModelSEED::Database"
+    },
+    ModelSEED::Exception::NoDatabase => {
+        isa => "ModelSEED::Exception::Database",
+        description => "When there is no database configuration",
+    },
+    ModelSEED::Exception::DatabaseConfigError => {
+        isa => "ModelSEED::Exception::Database",
+        description => "For invalid database configuration",
+        fields => [qw( configText dbName )],
+    }
+);
+1; 
+
+package ModelSEED::Exception::CLI;
+sub cli_error_text {
+    return "An unknown error occured.";
+}
+1;
+package ModelSEED::Exception::NoDatabase;
+sub cli_error_text { return <<ND;
+Unable to construct a database connection.
+Configure a database with the "stores" command
+to add a database. For usage, run: 
+
+\$ stores help
+ND
+}
+1;
+package ModelSEED::Exception::DatabaseConfigError;
+sub cli_error_text {
+    my ($self) = @_;
+    my $dbName = $self->dbName;
+    my $configText = $self->configText;
+return <<ND;
+Error configuring Database: $dbName
+Got invalid configuration:
+$configText
+Use the "stores" command to reconfigure this database.
+ND
+}
+1;


### PR DESCRIPTION
This is a working draft for doing structured exceptions for parts of the ModelSEED.
This is needed for properly handling exceptions for a CLI user:
- Defined CLI structured exceptions in ModelSEED::Exceptions.
  Subclasses of ModelSEED::Exception::CLI implement a function
  cli_error_text which describes the error for an end user.
- Implemented exceptions for ModelSEED::Database::Composite
  for bad configuration and no configuration error cases.
- Implemented error handlers for CLI functions that can
  use these structured exceptions.

TODO:
- Testing : must test each exception
- Testing : must test classes exceptions themselves
- Implement more exceptions

This addresses issue #8
