### PR TITLE
Fix 5.8

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -23,6 +23,7 @@ my $builder = Module::Build->new(
         "Devel::Size" => 0,
         "Exception::Class" => 0,
         "File::Copy::Recursive" => 0,
+        "File::Path" => "2.08",
         "HTTP::Message" => 0,
         "JSON::XS" => 0,
         "JSON::Any" => 0,

--- a/Build.PL
+++ b/Build.PL
@@ -14,6 +14,7 @@ my $builder = Module::Build->new(
     },
     requires => {
         "App::Cmd" => 0,
+        "autodie" => 0,
         "Class::Autouse" => 0,
         "Clone" => 0,
         "Config::Tiny" => 0,

--- a/lib/ModelSEED/App/Helpers.pm
+++ b/lib/ModelSEED/App/Helpers.pm
@@ -63,9 +63,12 @@ sub process_ref_string {
 sub get_base_ref {
     my ($self, $type, $username, $args, $options) = @_;
     my $ref;
-    my $from_stdin  = $options->{stdin} // 1;
-    my $from_config = $options->{config} // 1;
-    my $from_argv   = $options->{argv} // 1;
+    my $from_stdin  = $options->{stdin};
+    my $from_config = $options->{config};
+    my $from_argv   = $options->{argv};
+    $from_stdin  = 1 unless defined $from_stdin;
+    $from_config = 1 unless defined $from_config;
+    $from_argv   = 1 unless defined $from_argv;
     if($type ne "*") {
         my $arg = $args->[0];
         if($from_argv && $arg =~ /^$type\//) {
@@ -109,9 +112,12 @@ sub get_base_ref {
 sub get_base_refs {
     my ($self, $type, $args, $options) = @_;
     my $refs = [];
-    my $from_stdin  = $options->{stdin} // 1;
-    my $from_config = $options->{config} // 1;
-    my $from_argv   = $options->{argv} // 1;
+    my $from_stdin  = $options->{stdin};
+    my $from_config = $options->{config};
+    my $from_argv   = $options->{argv};
+    $from_stdin  = 1 unless defined $from_stdin;
+    $from_config = 1 unless defined $from_config;
+    $from_argv   = 1 unless defined $from_argv;
     if($from_argv) {
         foreach my $arg (@$args) {
             if($arg =~ /^$type\//) {

--- a/lib/ModelSEED/App/import/Command/model.pm
+++ b/lib/ModelSEED/App/import/Command/model.pm
@@ -66,7 +66,7 @@ sub execute {
         $opts->{source} = $opts->{list};
     }
     # Set source to 'model-seed' if it isn't defined
-    $opts->{source} //= 'model-seed';
+    $opts->{source} = 'model-seed' unless defined $opts->{source};
     my ($factory);
     if($opts->{source} eq 'model-seed') {
         $factory = ModelSEED::MS::Factories::FBAMODELFactory->new(

--- a/lib/ModelSEED/App/mseed/Command/list.pm
+++ b/lib/ModelSEED/App/mseed/Command/list.pm
@@ -129,13 +129,14 @@ sub determineColumns {
     my $types = $ref->base_types;
     my $type  = $types->[@$types - 1];
     my $with = [ "Reference" ];
+    my %with = map { $_ => 1 } @$with;
     push(@$with, @{$opts->{with} || []});
     if ( $opts->{verbose} ) {
         # If we asked for verbose, print out some default attributes
         my $additional_with = $self->verboseRules($type);
         foreach my $attr (@$additional_with) {
             # Append attributes unless we've already specified them
-            push(@$with, $attr) unless($attr ~~ @$with);
+            push(@$with, $attr) unless defined $with{$attr};
         }
     }
     return $with;

--- a/lib/ModelSEED/App/mseed/Command/revert.pm
+++ b/lib/ModelSEED/App/mseed/Command/revert.pm
@@ -32,6 +32,7 @@ sub execute {
         # Error if we have no ancestors
         $self->usage_error("No previous version for $refStr");
     } elsif(@$ancestors > 1) {
+        my %ancestors = map { $_ => 1 } @$ancestors;
         # If we have more than one ancestor
         my $uuid;
         if(@$args > 0) {
@@ -43,7 +44,7 @@ sub execute {
                 $uuid = $ref->id;
             };
         }
-        if(defined($uuid) && $uuid ~~ @$ancestors) {
+        if(defined($uuid) && defined $ancestors{$uuid}) {
             # Do the revert if the uuid is in the
             # referece object's ancestor list
             $self->_revert($store, $ref, $uuid);           

--- a/lib/ModelSEED/MS/Factories/ModelTable.pm
+++ b/lib/ModelSEED/MS/Factories/ModelTable.pm
@@ -7,7 +7,7 @@ our $headers = [ "Reaction Id", "Direction", "Compartment Id", "GPR" ];
 
 sub toTable {
     my ($self, $model, $config) = @_;
-    $config->{with_headers} //= 0;
+    $config->{with_headers} = 0 unless defined $config->{with_headers};
     my $reactions = $model->modelreactions;
     my $rows = [];
     foreach my $reaction (@$reactions) {

--- a/lib/ModelSEED/Reference.pm
+++ b/lib/ModelSEED/Reference.pm
@@ -338,8 +338,9 @@ sub _build_schema {
     my $schema = { children => {} };
     foreach my $name (keys %$defs) {
         my $definition = $defs->{$name};
-        if ( defined($definition->{parents}) &&
-            'ModelSEED::Store' ~~ $definition->{parents}) {
+        my $parents = $definition->{parents} || [];
+        my %parents = map { $_ => 1 } @{$definition->{parents}};
+        if ( defined $parents && defined $parents{'ModelSEED::Store'} ) {
             my $refName = lc(substr($name, 0,1)).substr($name,1);
             $schema->{children}->{$refName} =
                 _build_schema_recursive($name, $defs);


### PR DESCRIPTION
I'm trying to debug this to get things running on NERSC's Carver machine. That machine only has perl-5.8.8 and compiling a perlbrew of perl-5.12.4 isn't working well...

Most of the stuff is in place.

@pfrybar Can you add the dependencies for FileDB to the Build.PL file? Are there any that are going to be difficult to install correctly? (E.g. for the mongo interface, you need to install mongo to get the perl client installed).
