### PR TITLE
Change FBAFormulation and GapfillingFormulation

### DIFF
--- a/lib/ModelSEED/App/model/Command/runfba.pm
+++ b/lib/ModelSEED/App/model/Command/runfba.pm
@@ -39,6 +39,7 @@ sub opt_spec {
         ["nothermoerror","Do not include uncertainty in thermodynamic constraints"],
         ["minthermoerror","Minimize uncertainty in thermodynamic constraints"],
         ["html","Print FBA results in HTML"],
+        ["norun", "Do not run the configured FBA; print the config data instead"],
         ["help|h|?", "Print this usage information"],
     );
 }
@@ -79,6 +80,11 @@ sub execute {
 	}
 	my $exchange_factory = ModelSEED::MS::Factories::ExchangeFormatFactory->new();
 	my $fbaform = $exchange_factory->buildFBAFormulation($input);
+    # Print config and exit if norun is supplied
+    if ($opts->{norun}) {
+        print $out_fh $fbaform->toJSON;
+        exit();
+    }
     #Running FBA
     print STDERR "Running FBA..." if($opts->{verbose});
     my $fbaResult = $fbaform->runFBA();
@@ -89,12 +95,10 @@ sub execute {
 	    #Standard commands that save results of the analysis to the database
 	    if ($opts->{overwrite}) {
 	    	print STDERR "Saving model with FBA solution over original model...\n" if($opts->{verbose});
-	    	$model->add("fbaFormulations",$fbaform);
 	    	$store->save_object($ref,$model);
 	    } elsif ($opts->{save}) {
 			$ref = $helper->process_ref_string($opts->{save}, "model", $auth->username);
 			print STDERR "Saving model with FBA solution as new model ".$ref."...\n" if($opts->{verbose});
-			$model->add("fbaFormulations",$fbaform);
 			$store->save_object($ref,$model);
 	    }
 	    if ($opts->{html}) {

--- a/lib/ModelSEED/MS/Biochemistry.pm
+++ b/lib/ModelSEED/MS/Biochemistry.pm
@@ -28,7 +28,7 @@ sub _builddefinition {
 sub _builddataDirectory {
 	my ($self) = @_;
 	my $config = ModelSEED::Configuration->new();
-	if (defined($config->user_options()->{MFATK_CACHE})) {
+	if (defined($config->user_options) && defined($config->user_options()->{MFATK_CACHE})) {
 		return $config->user_options()->{MFATK_CACHE}."/";
 	}
 	return ModelSEED::utilities::MODELSEEDCORE()."/data/";

--- a/lib/ModelSEED/MS/DB/FBAFormulation.pm
+++ b/lib/ModelSEED/MS/DB/FBAFormulation.pm
@@ -17,8 +17,9 @@ use namespace::autoclean;
 extends 'ModelSEED::MS::IndexedObject';
 
 
+our $VERSION = 1;
 # PARENT:
-has parent => (is => 'rw', isa => 'ModelSEED::MS::Model', weak_ref => 1, type => 'parent', metaclass => 'Typed');
+has parent => (is => 'rw', isa => 'ModelSEED::Store', type => 'parent', metaclass => 'Typed');
 
 
 # ATTRIBUTES:
@@ -52,6 +53,7 @@ has simpleThermoConstraints => (is => 'rw', isa => 'Bool', printOrder => '15', d
 has thermodynamicConstraints => (is => 'rw', isa => 'Bool', printOrder => '16', default => '1', type => 'attribute', metaclass => 'Typed');
 has noErrorThermodynamicConstraints => (is => 'rw', isa => 'Bool', printOrder => '17', default => '1', type => 'attribute', metaclass => 'Typed');
 has minimizeErrorThermodynamicConstraints => (is => 'rw', isa => 'Bool', printOrder => '18', default => '1', type => 'attribute', metaclass => 'Typed');
+has model_uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '19', required => 1, type => 'attribute', metaclass => 'Typed');
 
 
 # ANCESTOR:
@@ -72,6 +74,7 @@ has media => (is => 'rw', isa => 'ModelSEED::MS::Media', type => 'link(Biochemis
 has geneKOs => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Feature]', type => 'link(Annotation,features,geneKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_geneKOs');
 has reactionKOs => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Reaction]', type => 'link(Biochemistry,reactions,reactionKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_reactionKOs');
 has secondaryMedia => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Media]', type => 'link(Biochemistry,media,secondaryMedia_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_secondaryMedia');
+has model => (is => 'rw', isa => 'ModelSEED::MS::Model', type => 'link(ModelSEED::Store,Model,model_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_model');
 
 
 # BUILDERS:
@@ -93,9 +96,14 @@ sub _build_secondaryMedia {
   my ($self) = @_;
   return $self->getLinkedObjectArray('Biochemistry','media',$self->secondaryMedia_uuids());
 }
+sub _build_model {
+  my ($self) = @_;
+  return $self->getLinkedObject('ModelSEED::Store','Model',$self->model_uuid());
+}
 
 
 # CONSTANTS:
+sub __version__ { return $VERSION; }
 sub _type { return 'FBAFormulation'; }
 
 my $attributes = [
@@ -334,10 +342,17 @@ my $attributes = [
             'default' => 1,
             'type' => 'Bool',
             'perm' => 'rw'
+          },
+          {
+            'req' => 1,
+            'printOrder' => 19,
+            'name' => 'model_uuid',
+            'type' => 'ModelSEED::uuid',
+            'perm' => 'rw'
           }
         ];
 
-my $attribute_map = {uuid => 0, modDate => 1, regulatorymodel_uuid => 2, media_uuid => 3, secondaryMedia_uuids => 4, fva => 5, comboDeletions => 6, fluxMinimization => 7, findMinimalMedia => 8, notes => 9, expressionData_uuid => 10, objectiveConstraintFraction => 11, allReversible => 12, defaultMaxFlux => 13, defaultMaxDrainFlux => 14, defaultMinDrainFlux => 15, maximizeObjective => 16, decomposeReversibleFlux => 17, decomposeReversibleDrainFlux => 18, fluxUseVariables => 19, drainfluxUseVariables => 20, geneKO_uuids => 21, reactionKO_uuids => 22, parameters => 23, uptakeLimits => 24, numberOfSolutions => 25, simpleThermoConstraints => 26, thermodynamicConstraints => 27, noErrorThermodynamicConstraints => 28, minimizeErrorThermodynamicConstraints => 29};
+my $attribute_map = {uuid => 0, modDate => 1, regulatorymodel_uuid => 2, media_uuid => 3, secondaryMedia_uuids => 4, fva => 5, comboDeletions => 6, fluxMinimization => 7, findMinimalMedia => 8, notes => 9, expressionData_uuid => 10, objectiveConstraintFraction => 11, allReversible => 12, defaultMaxFlux => 13, defaultMaxDrainFlux => 14, defaultMinDrainFlux => 15, maximizeObjective => 16, decomposeReversibleFlux => 17, decomposeReversibleDrainFlux => 18, fluxUseVariables => 19, drainfluxUseVariables => 20, geneKO_uuids => 21, reactionKO_uuids => 22, parameters => 23, uptakeLimits => 24, numberOfSolutions => 25, simpleThermoConstraints => 26, thermodynamicConstraints => 27, noErrorThermodynamicConstraints => 28, minimizeErrorThermodynamicConstraints => 29, model_uuid => 30};
 sub _attributes {
   my ($self, $key) = @_;
   if (defined($key)) {

--- a/lib/ModelSEED/MS/DB/GapfillingFormulation.pm
+++ b/lib/ModelSEED/MS/DB/GapfillingFormulation.pm
@@ -5,22 +5,24 @@
 # Development location: Mathematics and Computer Science Division, Argonne National Lab
 ########################################################################
 package ModelSEED::MS::DB::GapfillingFormulation;
-use ModelSEED::MS::BaseObject;
+use ModelSEED::MS::IndexedObject;
 use ModelSEED::MS::GapfillingGeneCandidate;
 use ModelSEED::MS::ReactionSetMultiplier;
 use ModelSEED::MS::GapfillingSolution;
 use Moose;
 use namespace::autoclean;
-extends 'ModelSEED::MS::BaseObject';
+extends 'ModelSEED::MS::IndexedObject';
 
 
+our $VERSION = 1;
 # PARENT:
-has parent => (is => 'rw', isa => 'ModelSEED::MS::Model', weak_ref => 1, type => 'parent', metaclass => 'Typed');
+has parent => (is => 'rw', isa => 'ModelSEED::Store', type => 'parent', metaclass => 'Typed');
 
 
 # ATTRIBUTES:
 has uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '0', lazy => 1, builder => '_build_uuid', type => 'attribute', metaclass => 'Typed');
-has fbaFormulation_uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '0', type => 'attribute', metaclass => 'Typed');
+has FBAFormulation_uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '0', type => 'attribute', metaclass => 'Typed');
+has model_uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '0', required => 1, type => 'attribute', metaclass => 'Typed');
 has mediaHypothesis => (is => 'rw', isa => 'Bool', printOrder => '0', default => '0', type => 'attribute', metaclass => 'Typed');
 has biomassHypothesis => (is => 'rw', isa => 'Bool', printOrder => '0', default => '0', type => 'attribute', metaclass => 'Typed');
 has gprHypothesis => (is => 'rw', isa => 'Bool', printOrder => '0', default => '0', type => 'attribute', metaclass => 'Typed');
@@ -52,18 +54,19 @@ has gapfillingSolutions => (is => 'rw', isa => 'ArrayRef[HashRef]', default => s
 
 
 # LINKS:
-has fbaFormulation => (is => 'rw', isa => 'ModelSEED::MS::FBAFormulation', type => 'link(Model,fbaFormulations,fbaFormulation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_fbaFormulation', weak_ref => 1);
+has FBAFormulation => (is => 'rw', isa => 'ModelSEED::MS::FBAFormulation', type => 'link(ModelSEED::Store,FBAFormulation,FBAFormulation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_FBAFormulation');
 has guaranteedReactions => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Reaction]', type => 'link(Biochemistry,reactions,guaranteedReaction_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_guaranteedReactions');
 has blacklistedReactions => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Reaction]', type => 'link(Biochemistry,reactions,blacklistedReaction_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_blacklistedReactions');
 has allowableCompartments => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Compartment]', type => 'link(Biochemistry,compartments,allowableCompartment_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_allowableCompartments');
+has model => (is => 'rw', isa => 'ModelSEED::MS::Model', type => 'link(ModelSEED::Store,Model,model_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_model');
 
 
 # BUILDERS:
 sub _build_uuid { return Data::UUID->new()->create_str(); }
 sub _build_modDate { return DateTime->now()->datetime(); }
-sub _build_fbaFormulation {
+sub _build_FBAFormulation {
   my ($self) = @_;
-  return $self->getLinkedObject('Model','fbaFormulations',$self->fbaFormulation_uuid());
+  return $self->getLinkedObject('ModelSEED::Store','FBAFormulation',$self->FBAFormulation_uuid());
 }
 sub _build_guaranteedReactions {
   my ($self) = @_;
@@ -77,9 +80,14 @@ sub _build_allowableCompartments {
   my ($self) = @_;
   return $self->getLinkedObjectArray('Biochemistry','compartments',$self->allowableCompartment_uuids());
 }
+sub _build_model {
+  my ($self) = @_;
+  return $self->getLinkedObject('ModelSEED::Store','Model',$self->model_uuid());
+}
 
 
 # CONSTANTS:
+sub __version__ { return $VERSION; }
 sub _type { return 'GapfillingFormulation'; }
 
 my $attributes = [
@@ -93,7 +101,14 @@ my $attributes = [
           {
             'req' => 0,
             'printOrder' => 0,
-            'name' => 'fbaFormulation_uuid',
+            'name' => 'FBAFormulation_uuid',
+            'type' => 'ModelSEED::uuid',
+            'perm' => 'rw'
+          },
+          {
+            'req' => 1,
+            'printOrder' => 0,
+            'name' => 'model_uuid',
             'type' => 'ModelSEED::uuid',
             'perm' => 'rw'
           },
@@ -242,7 +257,7 @@ my $attributes = [
           }
         ];
 
-my $attribute_map = {uuid => 0, fbaFormulation_uuid => 1, mediaHypothesis => 2, biomassHypothesis => 3, gprHypothesis => 4, reactionAdditionHypothesis => 5, balancedReactionsOnly => 6, guaranteedReaction_uuids => 7, blacklistedReaction_uuids => 8, allowableCompartment_uuids => 9, reactionActivationBonus => 10, drainFluxMultiplier => 11, directionalityMultiplier => 12, deltaGMultiplier => 13, noStructureMultiplier => 14, noDeltaGMultiplier => 15, biomassTransporterMultiplier => 16, singleTransporterMultiplier => 17, transporterMultiplier => 18, modDate => 19};
+my $attribute_map = {uuid => 0, FBAFormulation_uuid => 1, model_uuid => 2, mediaHypothesis => 3, biomassHypothesis => 4, gprHypothesis => 5, reactionAdditionHypothesis => 6, balancedReactionsOnly => 7, guaranteedReaction_uuids => 8, blacklistedReaction_uuids => 9, allowableCompartment_uuids => 10, reactionActivationBonus => 11, drainFluxMultiplier => 12, directionalityMultiplier => 13, deltaGMultiplier => 14, noStructureMultiplier => 15, noDeltaGMultiplier => 16, biomassTransporterMultiplier => 17, singleTransporterMultiplier => 18, transporterMultiplier => 19, modDate => 20};
 sub _attributes {
   my ($self, $key) = @_;
   if (defined($key)) {

--- a/lib/ModelSEED/MS/DB/GapgenFormulation.pm
+++ b/lib/ModelSEED/MS/DB/GapgenFormulation.pm
@@ -18,7 +18,7 @@ has parent => (is => 'rw', isa => 'ModelSEED::MS::Model', weak_ref => 1, type =>
 
 # ATTRIBUTES:
 has uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '0', lazy => 1, builder => '_build_uuid', type => 'attribute', metaclass => 'Typed');
-has fbaFormulation_uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '0', type => 'attribute', metaclass => 'Typed');
+has FBAFormulation_uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '0', type => 'attribute', metaclass => 'Typed');
 has mediaHypothesis => (is => 'rw', isa => 'Bool', printOrder => '0', default => '0', type => 'attribute', metaclass => 'Typed');
 has biomassHypothesis => (is => 'rw', isa => 'Bool', printOrder => '0', default => '0', type => 'attribute', metaclass => 'Typed');
 has gprHypothesis => (is => 'rw', isa => 'Bool', printOrder => '0', default => '0', type => 'attribute', metaclass => 'Typed');
@@ -36,16 +36,16 @@ has gapgenSolutions => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub {
 
 
 # LINKS:
-has fbaFormulation => (is => 'rw', isa => 'ModelSEED::MS::FBAFormulation', type => 'link(Model,fbaFormulations,fbaFormulation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_fbaFormulation', weak_ref => 1);
+has FBAFormulation => (is => 'rw', isa => 'ModelSEED::MS::FBAFormulation', type => 'link(ModelSEED::Store,FBAFormulation,FBAFormulation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_FBAFormulation');
 has referenceMedia => (is => 'rw', isa => 'ModelSEED::MS::Media', type => 'link(Biochemistry,media,referenceMedia_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_referenceMedia', weak_ref => 1);
 
 
 # BUILDERS:
 sub _build_uuid { return Data::UUID->new()->create_str(); }
 sub _build_modDate { return DateTime->now()->datetime(); }
-sub _build_fbaFormulation {
+sub _build_FBAFormulation {
   my ($self) = @_;
-  return $self->getLinkedObject('Model','fbaFormulations',$self->fbaFormulation_uuid());
+  return $self->getLinkedObject('ModelSEED::Store','FBAFormulation',$self->FBAFormulation_uuid());
 }
 sub _build_referenceMedia {
   my ($self) = @_;
@@ -67,7 +67,7 @@ my $attributes = [
           {
             'req' => 0,
             'printOrder' => 0,
-            'name' => 'fbaFormulation_uuid',
+            'name' => 'FBAFormulation_uuid',
             'type' => 'ModelSEED::uuid',
             'perm' => 'rw'
           },
@@ -119,7 +119,7 @@ my $attributes = [
           }
         ];
 
-my $attribute_map = {uuid => 0, fbaFormulation_uuid => 1, mediaHypothesis => 2, biomassHypothesis => 3, gprHypothesis => 4, reactionRemovalHypothesis => 5, referenceMedia_uuid => 6, modDate => 7};
+my $attribute_map = {uuid => 0, FBAFormulation_uuid => 1, mediaHypothesis => 2, biomassHypothesis => 3, gprHypothesis => 4, reactionRemovalHypothesis => 5, referenceMedia_uuid => 6, modDate => 7};
 sub _attributes {
   my ($self, $key) = @_;
   if (defined($key)) {

--- a/lib/ModelSEED/MS/DB/Model.pm
+++ b/lib/ModelSEED/MS/DB/Model.pm
@@ -10,14 +10,12 @@ use ModelSEED::MS::Biomass;
 use ModelSEED::MS::ModelCompartment;
 use ModelSEED::MS::ModelCompound;
 use ModelSEED::MS::ModelReaction;
-use ModelSEED::MS::FBAFormulation;
-use ModelSEED::MS::GapfillingFormulation;
 use Moose;
 use namespace::autoclean;
 extends 'ModelSEED::MS::IndexedObject';
 
 
-our $VERSION = 1;
+our $VERSION = 1.1;
 # PARENT:
 has parent => (is => 'rw', isa => 'ModelSEED::Store', type => 'parent', metaclass => 'Typed');
 
@@ -49,15 +47,12 @@ has biomasses => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { retur
 has modelcompartments => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { return []; }, type => 'child(ModelCompartment)', metaclass => 'Typed', reader => '_modelcompartments', printOrder => '1');
 has modelcompounds => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { return []; }, type => 'child(ModelCompound)', metaclass => 'Typed', reader => '_modelcompounds', printOrder => '2');
 has modelreactions => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { return []; }, type => 'child(ModelReaction)', metaclass => 'Typed', reader => '_modelreactions', printOrder => '3');
-has fbaFormulations => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { return []; }, type => 'child(FBAFormulation)', metaclass => 'Typed', reader => '_fbaFormulations', printOrder => '-1');
-has Gapfillingformulations => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { return []; }, type => 'child(GapfillingFormulation)', metaclass => 'Typed', reader => '_Gapfillingformulations', printOrder => '-1');
 
 
 # LINKS:
 has biochemistry => (is => 'rw', isa => 'ModelSEED::MS::Biochemistry', type => 'link(ModelSEED::Store,Biochemistry,biochemistry_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_biochemistry');
 has mapping => (is => 'rw', isa => 'ModelSEED::MS::Mapping', type => 'link(ModelSEED::Store,Mapping,mapping_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_mapping');
 has annotation => (is => 'rw', isa => 'ModelSEED::MS::Annotation', type => 'link(ModelSEED::Store,Annotation,annotation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_annotation');
-has modelanalysis => (is => 'rw', isa => 'ModelSEED::MS::ModelAnalysis', type => 'link(ModelSEED::Store,ModelAnalysis,modelanalysis_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelanalysis');
 
 
 # BUILDERS:
@@ -74,10 +69,6 @@ sub _build_mapping {
 sub _build_annotation {
   my ($self) = @_;
   return $self->getLinkedObject('ModelSEED::Store','Annotation',$self->annotation_uuid());
-}
-sub _build_modelanalysis {
-  my ($self) = @_;
-  return $self->getLinkedObject('ModelSEED::Store','ModelAnalysis',$self->modelanalysis_uuid());
 }
 
 
@@ -243,22 +234,10 @@ my $subobjects = [
             'name' => 'modelreactions',
             'type' => 'child',
             'class' => 'ModelReaction'
-          },
-          {
-            'printOrder' => -1,
-            'name' => 'fbaFormulations',
-            'type' => 'child',
-            'class' => 'FBAFormulation'
-          },
-          {
-            'printOrder' => -1,
-            'name' => 'Gapfillingformulations',
-            'type' => 'child',
-            'class' => 'GapfillingFormulation'
           }
         ];
 
-my $subobject_map = {biomasses => 0, modelcompartments => 1, modelcompounds => 2, modelreactions => 3, fbaFormulations => 4, Gapfillingformulations => 5};
+my $subobject_map = {biomasses => 0, modelcompartments => 1, modelcompounds => 2, modelreactions => 3};
 sub _subobjects {
   my ($self, $key) = @_;
   if (defined($key)) {
@@ -290,14 +269,6 @@ around 'modelcompounds' => sub {
 around 'modelreactions' => sub {
   my ($orig, $self) = @_;
   return $self->_build_all_objects('modelreactions');
-};
-around 'fbaFormulations' => sub {
-  my ($orig, $self) = @_;
-  return $self->_build_all_objects('fbaFormulations');
-};
-around 'Gapfillingformulations' => sub {
-  my ($orig, $self) = @_;
-  return $self->_build_all_objects('Gapfillingformulations');
 };
 
 

--- a/lib/ModelSEED/MS/FBAFormulation.pm
+++ b/lib/ModelSEED/MS/FBAFormulation.pm
@@ -8,6 +8,25 @@
 use strict;
 use ModelSEED::MS::DB::FBAFormulation;
 package ModelSEED::MS::FBAFormulation;
+
+=head1 ModelSEED::MS::GapfillingFormulation
+
+=head2 METHODS
+
+=head3 biochemistry
+
+Link to the model biochemistry object.
+
+=head3 mapping
+
+Link to the model mapping object.
+
+=head3 annotation
+
+Link to the model annotation object.
+
+=cut
+
 use Moose;
 use namespace::autoclean;
 extends 'ModelSEED::MS::DB::FBAFormulation';
@@ -25,6 +44,10 @@ has cplexLicense => ( is => 'rw', isa => 'Str',printOrder => '-1', type => 'msda
 has readableObjective => ( is => 'rw', isa => 'Str',printOrder => '2', type => 'msdata', metaclass => 'Typed', lazy => 1, builder => '_buildreadableObjective' );
 has mediaID => ( is => 'rw', isa => 'Str',printOrder => '0', type => 'msdata', metaclass => 'Typed', lazy => 1, builder => '_buildmediaID' );
 has knockouts => ( is => 'rw', isa => 'Str',printOrder => '3', type => 'msdata', metaclass => 'Typed', lazy => 1, builder => '_buildknockouts' );
+
+sub biochemistry { return $_[0]->model->biochemistry; }
+sub mapping { return $_[0]->model->mapping; }
+sub annotation { return $_[0]->model->annotation; }
 
 #***********************************************************************************************************
 # BUILDERS:
@@ -58,7 +81,7 @@ sub _buildmfatoolkitBinary {
 	my ($self) = @_;
 	my $config = ModelSEED::Configuration->new();
 	my $bin;
-	if (defined($config->user_options()->{MFATK_BIN})) {
+	if (defined($config->user_options()) && defined($config->user_options->{MFATK_BIN})) {
 		$bin = $config->user_options()->{MFATK_BIN};
 	} else {
             if ($^O =~ m/^MSWin/) {
@@ -87,7 +110,7 @@ sub _buildmfatoolkitDirectory {
 sub _builddataDirectory {
 	my ($self) = @_;
 	my $config = ModelSEED::Configuration->new();
-	if (defined($config->user_options()->{MFATK_CACHE})) {
+	if (defined($config->user_options()) && defined($config->user_options->{MFATK_CACHE})) {
 		return $config->user_options()->{MFATK_CACHE}."/";
 	}
 	return ModelSEED::utilities::MODELSEEDCORE()."/data/";
@@ -96,7 +119,7 @@ sub _builddataDirectory {
 sub _buildcplexLicense {
 	my ($self) = @_;
 	my $config = ModelSEED::Configuration->new();
-	if (defined($config->user_options()->{CPLEX_LICENCE})) {
+	if (defined($config->user_options()) && defined($config->user_options->{CPLEX_LICENCE})) {
 		return $config->user_options()->{CPLEX_LICENCE};
 	}
 	return "";
@@ -198,7 +221,7 @@ sub createJobDirectory {
 		biomassflux => "FLUX"
 	};
 	#Print model to Model.tbl
-	my $model = $self->parent();
+	my $model = $self->model;
 	my $mdlData = ["REACTIONS","LOAD;DIRECTIONALITY;COMPARTMENT;ASSOCIATED PEG"];
 	my $mdlrxn = $model->modelreactions();
 	for (my $i=0; $i < @{$mdlrxn}; $i++) {

--- a/lib/ModelSEED/MS/Factories/ExchangeFormatFactory.pm
+++ b/lib/ModelSEED/MS/Factories/ExchangeFormatFactory.pm
@@ -5,28 +5,13 @@
 # Development location: Mathematics and Computer Science Division, Argonne National Lab
 # Date of module creation: 2012-03-15T16:44:01
 ########################################################################
-use strict;
-use ModelSEED::utilities;
-use Data::Dumper;
 package ModelSEED::MS::Factories::ExchangeFormatFactory;
+use strict;
+use common::sense;
 use Moose;
-use namespace::autoclean;
-#***********************************************************************************************************
-# ATTRIBUTES:
-#***********************************************************************************************************
-
-#***********************************************************************************************************
-# BUILDERS:
-#***********************************************************************************************************
-
-#***********************************************************************************************************
-# CONSTANTS:
-#***********************************************************************************************************
-
-
-#***********************************************************************************************************
-# FUNCTIONS:
-#***********************************************************************************************************
+use ModelSEED::utilities;
+use ModelSEED::MS::FBAFormulation;
+use ModelSEED::MS::GapfillingFormulation;
 
 =head3 buildFBAFormulation
 
@@ -93,11 +78,11 @@ sub buildFBAFormulation {
 	if (!defined($media)) {
 		ModelSEED::utilities::ERROR("Media referenced in formulation not found in database: ".$data->{media});
 	}
-	#print STDERR Data::Dumper->Dump([$data]);
 	#Creating objects and populating with provenance objects
 	my $form = ModelSEED::MS::FBAFormulation->new({
-		parent => $model,
-		media_uuid => $media->uuid(),
+        model => $model,
+        model_uuid => $model->uuid,
+		media_uuid => $media->uuid,
 		type => $data->{type},
 		notes => $data->{notes},
 		growthConstraint => $data->{growthConstraint},
@@ -157,10 +142,63 @@ sub buildGapfillingFormulation {
 	my $data = $self->parseExchangeFileArray($args);
 	#Setting default values for exchange format attributes
 	$data = ModelSEED::utilities::ARGS($data,[],{
-		fbaFormulation => $fbaform,
+		FBAFormulation => $fbaform,
 		balancedReactionsOnly => 1,
-		guaranteedReactions => "Reaction/ModelSEED/rxn13782|Reaction/ModelSEED/rxn13783|Reaction/ModelSEED/rxn13784|Reaction/ModelSEED/rxn05294|Reaction/ModelSEED/rxn05295|Reaction/ModelSEED/rxn05296|Reaction/ModelSEED/rxn10002|Reaction/ModelSEED/rxn10088|Reaction/ModelSEED/rxn11921|Reaction/ModelSEED/rxn11922|Reaction/ModelSEED/rxn10200|Reaction/ModelSEED/rxn11923|Reaction/ModelSEED/rxn05029",
-		blacklistedReactions => "Reaction/ModelSEED/rxn12985|Reaction/ModelSEED/rxn00238|Reaction/ModelSEED/rxn07058|Reaction/ModelSEED/rxn05305|Reaction/ModelSEED/rxn00154|Reaction/ModelSEED/rxn09037|Reaction/ModelSEED/rxn10643|Reaction/ModelSEED/rxn11317|Reaction/ModelSEED/rxn05254|Reaction/ModelSEED/rxn05257|Reaction/ModelSEED/rxn05258|Reaction/ModelSEED/rxn05259|Reaction/ModelSEED/rxn05264|Reaction/ModelSEED/rxn05268|Reaction/ModelSEED/rxn05269|Reaction/ModelSEED/rxn05270|Reaction/ModelSEED/rxn05271|Reaction/ModelSEED/rxn05272|Reaction/ModelSEED/rxn05273|Reaction/ModelSEED/rxn05274|Reaction/ModelSEED/rxn05275|Reaction/ModelSEED/rxn05276|Reaction/ModelSEED/rxn05277|Reaction/ModelSEED/rxn05278|Reaction/ModelSEED/rxn05279|Reaction/ModelSEED/rxn05280|Reaction/ModelSEED/rxn05281|Reaction/ModelSEED/rxn05282|Reaction/ModelSEED/rxn05283|Reaction/ModelSEED/rxn05284|Reaction/ModelSEED/rxn05285|Reaction/ModelSEED/rxn05286|Reaction/ModelSEED/rxn05963|Reaction/ModelSEED/rxn05964|Reaction/ModelSEED/rxn05971|Reaction/ModelSEED/rxn05989|Reaction/ModelSEED/rxn05990|Reaction/ModelSEED/rxn06041|Reaction/ModelSEED/rxn06042|Reaction/ModelSEED/rxn06043|Reaction/ModelSEED/rxn06044|Reaction/ModelSEED/rxn06045|Reaction/ModelSEED/rxn06046|Reaction/ModelSEED/rxn06079|Reaction/ModelSEED/rxn06080|Reaction/ModelSEED/rxn06081|Reaction/ModelSEED/rxn06086|Reaction/ModelSEED/rxn06087|Reaction/ModelSEED/rxn06088|Reaction/ModelSEED/rxn06089|Reaction/ModelSEED/rxn06090|Reaction/ModelSEED/rxn06091|Reaction/ModelSEED/rxn06092|Reaction/ModelSEED/rxn06138|Reaction/ModelSEED/rxn06139|Reaction/ModelSEED/rxn06140|Reaction/ModelSEED/rxn06141|Reaction/ModelSEED/rxn06145|Reaction/ModelSEED/rxn06217|Reaction/ModelSEED/rxn06218|Reaction/ModelSEED/rxn06219|Reaction/ModelSEED/rxn06220|Reaction/ModelSEED/rxn06221|Reaction/ModelSEED/rxn06222|Reaction/ModelSEED/rxn06223|Reaction/ModelSEED/rxn06235|Reaction/ModelSEED/rxn06362|Reaction/ModelSEED/rxn06368|Reaction/ModelSEED/rxn06378|Reaction/ModelSEED/rxn06474|Reaction/ModelSEED/rxn06475|Reaction/ModelSEED/rxn06502|Reaction/ModelSEED/rxn06562|Reaction/ModelSEED/rxn06569|Reaction/ModelSEED/rxn06604|Reaction/ModelSEED/rxn06702|Reaction/ModelSEED/rxn06706|Reaction/ModelSEED/rxn06715|Reaction/ModelSEED/rxn06803|Reaction/ModelSEED/rxn06811|Reaction/ModelSEED/rxn06812|Reaction/ModelSEED/rxn06850|Reaction/ModelSEED/rxn06901|Reaction/ModelSEED/rxn06971|Reaction/ModelSEED/rxn06999|Reaction/ModelSEED/rxn07123|Reaction/ModelSEED/rxn07172|Reaction/ModelSEED/rxn07254|Reaction/ModelSEED/rxn07255|Reaction/ModelSEED/rxn07269|Reaction/ModelSEED/rxn07451|Reaction/ModelSEED/rxn09037|Reaction/ModelSEED/rxn10018|Reaction/ModelSEED/rxn10077|Reaction/ModelSEED/rxn10096|Reaction/ModelSEED/rxn10097|Reaction/ModelSEED/rxn10098|Reaction/ModelSEED/rxn10099|Reaction/ModelSEED/rxn10101|Reaction/ModelSEED/rxn10102|Reaction/ModelSEED/rxn10103|Reaction/ModelSEED/rxn10104|Reaction/ModelSEED/rxn10105|Reaction/ModelSEED/rxn10106|Reaction/ModelSEED/rxn10107|Reaction/ModelSEED/rxn10109|Reaction/ModelSEED/rxn10111|Reaction/ModelSEED/rxn10403|Reaction/ModelSEED/rxn10410|Reaction/ModelSEED/rxn10416|Reaction/ModelSEED/rxn11313|Reaction/ModelSEED/rxn11316|Reaction/ModelSEED/rxn11318|Reaction/ModelSEED/rxn11353|Reaction/ModelSEED/rxn05224|Reaction/ModelSEED/rxn05795|Reaction/ModelSEED/rxn05796|Reaction/ModelSEED/rxn05797|Reaction/ModelSEED/rxn05798|Reaction/ModelSEED/rxn05799|Reaction/ModelSEED/rxn05801|Reaction/ModelSEED/rxn05802|Reaction/ModelSEED/rxn05803|Reaction/ModelSEED/rxn05804|Reaction/ModelSEED/rxn05805|Reaction/ModelSEED/rxn05806|Reaction/ModelSEED/rxn05808|Reaction/ModelSEED/rxn05812|Reaction/ModelSEED/rxn05815|Reaction/ModelSEED/rxn05832|Reaction/ModelSEED/rxn05836|Reaction/ModelSEED/rxn05851|Reaction/ModelSEED/rxn05857|Reaction/ModelSEED/rxn05869|Reaction/ModelSEED/rxn05870|Reaction/ModelSEED/rxn05884|Reaction/ModelSEED/rxn05888|Reaction/ModelSEED/rxn05896|Reaction/ModelSEED/rxn05898|Reaction/ModelSEED/rxn05900|Reaction/ModelSEED/rxn05903|Reaction/ModelSEED/rxn05904|Reaction/ModelSEED/rxn05905|Reaction/ModelSEED/rxn05911|Reaction/ModelSEED/rxn05921|Reaction/ModelSEED/rxn05925|Reaction/ModelSEED/rxn05936|Reaction/ModelSEED/rxn05947|Reaction/ModelSEED/rxn05956|Reaction/ModelSEED/rxn05959|Reaction/ModelSEED/rxn05960|Reaction/ModelSEED/rxn05980|Reaction/ModelSEED/rxn05991|Reaction/ModelSEED/rxn05992|Reaction/ModelSEED/rxn05999|Reaction/ModelSEED/rxn06001|Reaction/ModelSEED/rxn06014|Reaction/ModelSEED/rxn06017|Reaction/ModelSEED/rxn06021|Reaction/ModelSEED/rxn06026|Reaction/ModelSEED/rxn06027|Reaction/ModelSEED/rxn06034|Reaction/ModelSEED/rxn06048|Reaction/ModelSEED/rxn06052|Reaction/ModelSEED/rxn06053|Reaction/ModelSEED/rxn06054|Reaction/ModelSEED/rxn06057|Reaction/ModelSEED/rxn06059|Reaction/ModelSEED/rxn06061|Reaction/ModelSEED/rxn06102|Reaction/ModelSEED/rxn06103|Reaction/ModelSEED/rxn06127|Reaction/ModelSEED/rxn06128|Reaction/ModelSEED/rxn06129|Reaction/ModelSEED/rxn06130|Reaction/ModelSEED/rxn06131|Reaction/ModelSEED/rxn06132|Reaction/ModelSEED/rxn06137|Reaction/ModelSEED/rxn06146|Reaction/ModelSEED/rxn06161|Reaction/ModelSEED/rxn06167|Reaction/ModelSEED/rxn06172|Reaction/ModelSEED/rxn06174|Reaction/ModelSEED/rxn06175|Reaction/ModelSEED/rxn06187|Reaction/ModelSEED/rxn06189|Reaction/ModelSEED/rxn06203|Reaction/ModelSEED/rxn06204|Reaction/ModelSEED/rxn06246|Reaction/ModelSEED/rxn06261|Reaction/ModelSEED/rxn06265|Reaction/ModelSEED/rxn06266|Reaction/ModelSEED/rxn06286|Reaction/ModelSEED/rxn06291|Reaction/ModelSEED/rxn06294|Reaction/ModelSEED/rxn06310|Reaction/ModelSEED/rxn06320|Reaction/ModelSEED/rxn06327|Reaction/ModelSEED/rxn06334|Reaction/ModelSEED/rxn06337|Reaction/ModelSEED/rxn06339|Reaction/ModelSEED/rxn06342|Reaction/ModelSEED/rxn06343|Reaction/ModelSEED/rxn06350|Reaction/ModelSEED/rxn06352|Reaction/ModelSEED/rxn06358|Reaction/ModelSEED/rxn06361|Reaction/ModelSEED/rxn06369|Reaction/ModelSEED/rxn06380|Reaction/ModelSEED/rxn06395|Reaction/ModelSEED/rxn06415|Reaction/ModelSEED/rxn06419|Reaction/ModelSEED/rxn06420|Reaction/ModelSEED/rxn06421|Reaction/ModelSEED/rxn06423|Reaction/ModelSEED/rxn06450|Reaction/ModelSEED/rxn06457|Reaction/ModelSEED/rxn06463|Reaction/ModelSEED/rxn06464|Reaction/ModelSEED/rxn06466|Reaction/ModelSEED/rxn06471|Reaction/ModelSEED/rxn06482|Reaction/ModelSEED/rxn06483|Reaction/ModelSEED/rxn06486|Reaction/ModelSEED/rxn06492|Reaction/ModelSEED/rxn06497|Reaction/ModelSEED/rxn06498|Reaction/ModelSEED/rxn06501|Reaction/ModelSEED/rxn06505|Reaction/ModelSEED/rxn06506|Reaction/ModelSEED/rxn06521|Reaction/ModelSEED/rxn06534|Reaction/ModelSEED/rxn06580|Reaction/ModelSEED/rxn06585|Reaction/ModelSEED/rxn06593|Reaction/ModelSEED/rxn06609|Reaction/ModelSEED/rxn06613|Reaction/ModelSEED/rxn06654|Reaction/ModelSEED/rxn06667|Reaction/ModelSEED/rxn06676|Reaction/ModelSEED/rxn06693|Reaction/ModelSEED/rxn06730|Reaction/ModelSEED/rxn06746|Reaction/ModelSEED/rxn06762|Reaction/ModelSEED/rxn06779|Reaction/ModelSEED/rxn06790|Reaction/ModelSEED/rxn06791|Reaction/ModelSEED/rxn06792|Reaction/ModelSEED/rxn06793|Reaction/ModelSEED/rxn06794|Reaction/ModelSEED/rxn06795|Reaction/ModelSEED/rxn06796|Reaction/ModelSEED/rxn06797|Reaction/ModelSEED/rxn06821|Reaction/ModelSEED/rxn06826|Reaction/ModelSEED/rxn06827|Reaction/ModelSEED/rxn06829|Reaction/ModelSEED/rxn06839|Reaction/ModelSEED/rxn06841|Reaction/ModelSEED/rxn06842|Reaction/ModelSEED/rxn06851|Reaction/ModelSEED/rxn06866|Reaction/ModelSEED/rxn06867|Reaction/ModelSEED/rxn06873|Reaction/ModelSEED/rxn06885|Reaction/ModelSEED/rxn06891|Reaction/ModelSEED/rxn06892|Reaction/ModelSEED/rxn06896|Reaction/ModelSEED/rxn06938|Reaction/ModelSEED/rxn06939|Reaction/ModelSEED/rxn06944|Reaction/ModelSEED/rxn06951|Reaction/ModelSEED/rxn06952|Reaction/ModelSEED/rxn06955|Reaction/ModelSEED/rxn06957|Reaction/ModelSEED/rxn06960|Reaction/ModelSEED/rxn06964|Reaction/ModelSEED/rxn06965|Reaction/ModelSEED/rxn07086|Reaction/ModelSEED/rxn07097|Reaction/ModelSEED/rxn07103|Reaction/ModelSEED/rxn07104|Reaction/ModelSEED/rxn07105|Reaction/ModelSEED/rxn07106|Reaction/ModelSEED/rxn07107|Reaction/ModelSEED/rxn07109|Reaction/ModelSEED/rxn07119|Reaction/ModelSEED/rxn07179|Reaction/ModelSEED/rxn07186|Reaction/ModelSEED/rxn07187|Reaction/ModelSEED/rxn07188|Reaction/ModelSEED/rxn07195|Reaction/ModelSEED/rxn07196|Reaction/ModelSEED/rxn07197|Reaction/ModelSEED/rxn07198|Reaction/ModelSEED/rxn07201|Reaction/ModelSEED/rxn07205|Reaction/ModelSEED/rxn07206|Reaction/ModelSEED/rxn07210|Reaction/ModelSEED/rxn07244|Reaction/ModelSEED/rxn07245|Reaction/ModelSEED/rxn07253|Reaction/ModelSEED/rxn07275|Reaction/ModelSEED/rxn07299|Reaction/ModelSEED/rxn07302|Reaction/ModelSEED/rxn07651|Reaction/ModelSEED/rxn07723|Reaction/ModelSEED/rxn07736|Reaction/ModelSEED/rxn07878|Reaction/ModelSEED/rxn11417|Reaction/ModelSEED/rxn11582|Reaction/ModelSEED/rxn11593|Reaction/ModelSEED/rxn11597|Reaction/ModelSEED/rxn11615|Reaction/ModelSEED/rxn11617|Reaction/ModelSEED/rxn11619|Reaction/ModelSEED/rxn11620|Reaction/ModelSEED/rxn11624|Reaction/ModelSEED/rxn11626|Reaction/ModelSEED/rxn11638|Reaction/ModelSEED/rxn11648|Reaction/ModelSEED/rxn11651|Reaction/ModelSEED/rxn11665|Reaction/ModelSEED/rxn11666|Reaction/ModelSEED/rxn11667|Reaction/ModelSEED/rxn11698|Reaction/ModelSEED/rxn11983|Reaction/ModelSEED/rxn11986|Reaction/ModelSEED/rxn11994|Reaction/ModelSEED/rxn12006|Reaction/ModelSEED/rxn12007|Reaction/ModelSEED/rxn12014|Reaction/ModelSEED/rxn12017|Reaction/ModelSEED/rxn12022|Reaction/ModelSEED/rxn12160|Reaction/ModelSEED/rxn12161|Reaction/ModelSEED/rxn01267",
+		guaranteedReactions => join("|", map { "Reaction/ModelSEED/$_" } qw(
+rxn13782 rxn13783 rxn13784 rxn05294 rxn05295 rxn05296 rxn10002
+rxn10088 rxn11921 rxn11922 rxn10200 rxn11923 rxn05029
+        )),
+		blacklistedReactions => join("|", map { "Reaction/ModelSEED/$_" } qw(
+rxn12985 rxn00238 rxn07058 rxn05305 rxn00154 rxn09037 rxn10643
+rxn11317 rxn05254 rxn05257 rxn05258 rxn05259 rxn05264 rxn05268
+rxn05269 rxn05270 rxn05271 rxn05272 rxn05273 rxn05274 rxn05275
+rxn05276 rxn05277 rxn05278 rxn05279 rxn05280 rxn05281 rxn05282
+rxn05283 rxn05284 rxn05285 rxn05286 rxn05963 rxn05964 rxn05971
+rxn05989 rxn05990 rxn06041 rxn06042 rxn06043 rxn06044 rxn06045
+rxn06046 rxn06079 rxn06080 rxn06081 rxn06086 rxn06087 rxn06088
+rxn06089 rxn06090 rxn06091 rxn06092 rxn06138 rxn06139 rxn06140
+rxn06141 rxn06145 rxn06217 rxn06218 rxn06219 rxn06220 rxn06221
+rxn06222 rxn06223 rxn06235 rxn06362 rxn06368 rxn06378 rxn06474
+rxn06475 rxn06502 rxn06562 rxn06569 rxn06604 rxn06702 rxn06706
+rxn06715 rxn06803 rxn06811 rxn06812 rxn06850 rxn06901 rxn06971
+rxn06999 rxn07123 rxn07172 rxn07254 rxn07255 rxn07269 rxn07451
+rxn09037 rxn10018 rxn10077 rxn10096 rxn10097 rxn10098 rxn10099
+rxn10101 rxn10102 rxn10103 rxn10104 rxn10105 rxn10106 rxn10107
+rxn10109 rxn10111 rxn10403 rxn10410 rxn10416 rxn11313 rxn11316
+rxn11318 rxn11353 rxn05224 rxn05795 rxn05796 rxn05797 rxn05798
+rxn05799 rxn05801 rxn05802 rxn05803 rxn05804 rxn05805 rxn05806
+rxn05808 rxn05812 rxn05815 rxn05832 rxn05836 rxn05851 rxn05857
+rxn05869 rxn05870 rxn05884 rxn05888 rxn05896 rxn05898 rxn05900
+rxn05903 rxn05904 rxn05905 rxn05911 rxn05921 rxn05925 rxn05936
+rxn05947 rxn05956 rxn05959 rxn05960 rxn05980 rxn05991 rxn05992
+rxn05999 rxn06001 rxn06014 rxn06017 rxn06021 rxn06026 rxn06027
+rxn06034 rxn06048 rxn06052 rxn06053 rxn06054 rxn06057 rxn06059
+rxn06061 rxn06102 rxn06103 rxn06127 rxn06128 rxn06129 rxn06130
+rxn06131 rxn06132 rxn06137 rxn06146 rxn06161 rxn06167 rxn06172
+rxn06174 rxn06175 rxn06187 rxn06189 rxn06203 rxn06204 rxn06246
+rxn06261 rxn06265 rxn06266 rxn06286 rxn06291 rxn06294 rxn06310
+rxn06320 rxn06327 rxn06334 rxn06337 rxn06339 rxn06342 rxn06343
+rxn06350 rxn06352 rxn06358 rxn06361 rxn06369 rxn06380 rxn06395
+rxn06415 rxn06419 rxn06420 rxn06421 rxn06423 rxn06450 rxn06457
+rxn06463 rxn06464 rxn06466 rxn06471 rxn06482 rxn06483 rxn06486
+rxn06492 rxn06497 rxn06498 rxn06501 rxn06505 rxn06506 rxn06521
+rxn06534 rxn06580 rxn06585 rxn06593 rxn06609 rxn06613 rxn06654
+rxn06667 rxn06676 rxn06693 rxn06730 rxn06746 rxn06762 rxn06779
+rxn06790 rxn06791 rxn06792 rxn06793 rxn06794 rxn06795 rxn06796
+rxn06797 rxn06821 rxn06826 rxn06827 rxn06829 rxn06839 rxn06841
+rxn06842 rxn06851 rxn06866 rxn06867 rxn06873 rxn06885 rxn06891
+rxn06892 rxn06896 rxn06938 rxn06939 rxn06944 rxn06951 rxn06952
+rxn06955 rxn06957 rxn06960 rxn06964 rxn06965 rxn07086 rxn07097
+rxn07103 rxn07104 rxn07105 rxn07106 rxn07107 rxn07109 rxn07119
+rxn07179 rxn07186 rxn07187 rxn07188 rxn07195 rxn07196 rxn07197
+rxn07198 rxn07201 rxn07205 rxn07206 rxn07210 rxn07244 rxn07245
+rxn07253 rxn07275 rxn07299 rxn07302 rxn07651 rxn07723 rxn07736
+rxn07878 rxn11417 rxn11582 rxn11593 rxn11597 rxn11615 rxn11617
+rxn11619 rxn11620 rxn11624 rxn11626 rxn11638 rxn11648 rxn11651
+rxn11665 rxn11666 rxn11667 rxn11698 rxn11983 rxn11986 rxn11994
+rxn12006 rxn12007 rxn12014 rxn12017 rxn12022 rxn12160 rxn12161
+rxn01267
+        )),
 		allowableCompartments => "Compartment/id/c|Compartment/id/e|Compartment/id/p",
 		mediaHypothesis => 1,
 		biomassHypothesis => 1,
@@ -180,9 +218,10 @@ sub buildGapfillingFormulation {
 	});
 	#Creating gapfilling formulation object
 	my $gapform = ModelSEED::MS::GapfillingFormulation->new({
-		parent => $model,
-		fbaFormulation_uuid => $fbaform->uuid(),
-		fbaFormulation => $fbaform,
+        model => $model,
+		model_uuid => $model->uuid,
+	    FBAFormulation_uuid => $fbaform->uuid,
+		FBAFormulation => $fbaform,
 		balancedReactionsOnly => $data->{balancedReactionsOnly},
 		reactionActivationBonus => $data->{reactionActivationBonus},
 		drainFluxMultiplier => $data->{drainFluxMultiplier},
@@ -198,7 +237,6 @@ sub buildGapfillingFormulation {
 		gprHypothesis => $data->{gprHypothesis},
 		reactionAdditionHypothesis => $data->{reactionAdditionHypothesis},
 	});
-	$model->add("fbaFormulations",$fbaform);
 	$gapform->parseGeneCandidates({geneCandidates => $data->{gapfillingGeneCandidates}});
 	$gapform->parseSetMultipliers({sets => $data->{reactionSetMultipliers}});
 	$gapform->parseGuaranteedReactions({string => $data->{guaranteedReactions}});
@@ -247,7 +285,7 @@ sub buildGapgenFormulation {
 	}
 	#Creating gapfilling formulation object
 	my $gapgenform = ModelSEED::MS::GapgenFormulation->new({
-		parent => $model,
+		model_uuid => $model->uuid,
 		fbaFormulation_uuid => $fbaform->uuid(),
 		fbaFormulation => $fbaform,
 		referenceMedia_uuid => $media->uuid(),
@@ -257,7 +295,6 @@ sub buildGapgenFormulation {
 		gprHypothesis => $data->{gprHypothesis},
 		reactionRemovalHypothesis => $data->{reactionRemovalHypothesis},
 	});
-	$model->add("fbaFormulations",$fbaform);
 	return $gapgenform;
 }
 
@@ -473,3 +510,4 @@ sub reconcileReference {
 }
 
 __PACKAGE__->meta->make_immutable;
+1;

--- a/lib/ModelSEED/MS/GapfillingFormulation.pm
+++ b/lib/ModelSEED/MS/GapfillingFormulation.pm
@@ -8,25 +8,32 @@
 use strict;
 use ModelSEED::MS::DB::GapfillingFormulation;
 package ModelSEED::MS::GapfillingFormulation;
+
+=head1 ModelSEED::MS::GapfillingFormulation
+
+=head2 METHODS
+
+=head3 biochemistry
+
+Link to the model biochemistry object.
+
+=head3 mapping
+
+Link to the model mapping object.
+
+=head3 annotation
+
+Link to the model annotation object.
+
+=cut
+
 use Moose;
 use namespace::autoclean;
 extends 'ModelSEED::MS::DB::GapfillingFormulation';
-#***********************************************************************************************************
-# ADDITIONAL ATTRIBUTES:
-#***********************************************************************************************************
 
-#***********************************************************************************************************
-# BUILDERS:
-#***********************************************************************************************************
-
-
-#***********************************************************************************************************
-# CONSTANTS:
-#***********************************************************************************************************
-
-#***********************************************************************************************************
-# FUNCTIONS:
-#***********************************************************************************************************
+sub biochemistry { return $_[0]->model->biochemistry; }
+sub mapping { return $_[0]->model->mapping; }
+sub annotation { return $_[0]->model->annotation; }
 
 =head3 calculateReactionCosts
 
@@ -120,9 +127,9 @@ Description:
 sub prepareFBAFormulation {
 	my ($self,$args) = @_;
 	my $form;
-	if (!defined($self->fbaFormulation_uuid())) {
+	if (!defined($self->FBAFormulation_uuid())) {
 		my $exFact = ModelSEED::MS::Factories::ExchangeFormatFactory->new();
-		$form = $exFact->buildFBAFormulation({model => $self->parent(),overrides => {
+		$form = $exFact->buildFBAFormulation({model => $self->model,overrides => {
 			media => "Media/name/Complete",
 			notes => "Default gapfilling FBA formulation",
 			allReversible => 1,
@@ -136,7 +143,7 @@ sub prepareFBAFormulation {
 			}]
 		}});
 	} else {
-		$form = $self->fbaFormulation();
+		$form = $self->FBAFormulation;
 	}
 	if ($form->media()->name() eq "Complete") {
 		if ($form->defaultMaxDrainFlux() < 10000) {
@@ -247,7 +254,7 @@ Description:
 
 sub printBiomassComponentReactions {
 	my ($self,$args) = @_;
-	my $form = $self->fbaFormulation();
+	my $form = $self->FBAFormulation();
 	my $filename = $form->jobDirectory()."/BiomassHypothesisEquations.txt";
 	my $output = ["id\tequation\tname"];
 	my $bio = $self->model()->biomasses()->[0];
@@ -311,7 +318,7 @@ sub runGapFilling {
 	my $filedata = ModelSEED::utilities::LOADFILE($directory."CompleteGapfillingOutput.txt");
 	my $gfsolution = $self->add("gapfillingSolutions",{});
 	my $count = 0;
-	my $model = $self->parent();
+	my $model = $self->model;
 	for (my $i=0; $i < @{$filedata}; $i++) {
 		if ($filedata->[$i] =~ m/^bio00001/) {
 			my $array = [split(/\t/,$filedata->[$i])];

--- a/lib/ModelSEED/MS/Metadata/Definitions.pm
+++ b/lib/ModelSEED/MS/Metadata/Definitions.pm
@@ -4,7 +4,7 @@ package ModelSEED::MS::Metadata::Definitions;
 my $objectDefinitions = {};
 
 $objectDefinitions->{FBAFormulation} = {
-	parents => ['Model'],
+	parents => ['ModelSEED::Store'],
 	class => 'indexed',
 	attributes => [
 		{name => 'uuid',printOrder => -1,perm => 'rw',type => 'ModelSEED::uuid',req => 0},
@@ -37,6 +37,7 @@ $objectDefinitions->{FBAFormulation} = {
 		{name => 'thermodynamicConstraints',printOrder => 16,perm => 'rw',type => 'Bool',req => 0,default => 1},
 		{name => 'noErrorThermodynamicConstraints',printOrder => 17,perm => 'rw',type => 'Bool',req => 0,default => 1},
 		{name => 'minimizeErrorThermodynamicConstraints',printOrder => 18,perm => 'rw',type => 'Bool',req => 0,default => 1},
+        {name => 'model_uuid', printOrder => 19, perm => 'rw', type => 'ModelSEED::uuid', req => 1},
 	],
 	subobjects => [
 		{name => "fbaObjectiveTerms",printOrder => -1,class => "FBAObjectiveTerm",type => "encompassed"},
@@ -52,8 +53,10 @@ $objectDefinitions->{FBAFormulation} = {
 		{name => "geneKOs",attribute => "geneKO_uuids",parent => "Annotation",method=>"features",array => 1},
 		{name => "reactionKOs",attribute => "reactionKO_uuids",parent => "Biochemistry",method=>"reactions",array => 1},
 		{name => "secondaryMedia",attribute => "secondaryMedia_uuids",parent => "Biochemistry",method=>"media",array => 1},
+        {name => "model", attribute => "model_uuid", parent => "ModelSEED::Store", method => "Model", weak => 0},
 	],
     reference_id_types => [ qw(uuid) ],
+    version => 1.0,
 };
 	
 $objectDefinitions->{FBAConstraint} = {
@@ -308,7 +311,7 @@ $objectDefinitions->{GapgenFormulation} = {
 	class => 'child',
 	attributes => [
 		{name => 'uuid',printOrder => 0,perm => 'rw',type => 'ModelSEED::uuid',req => 0},
-		{name => 'fbaFormulation_uuid',printOrder => 0,perm => 'rw',type => 'ModelSEED::uuid',req => 0},
+		{name => 'FBAFormulation_uuid',printOrder => 0,perm => 'rw',type => 'ModelSEED::uuid',req => 0},
 		{name => 'mediaHypothesis',printOrder => 0,perm => 'rw',type => 'Bool',req => 0,default => "0"},
 		{name => 'biomassHypothesis',printOrder => 0,perm => 'rw',type => 'Bool',req => 0,default => "0"},
 		{name => 'gprHypothesis',printOrder => 0,perm => 'rw',type => 'Bool',req => 0,default => "0"},
@@ -321,7 +324,7 @@ $objectDefinitions->{GapgenFormulation} = {
 	],
 	primarykeys => [ qw(uuid) ],
 	links => [
-		{name => "fbaFormulation",attribute => "fbaFormulation_uuid",parent => "Model",method=>"fbaFormulations"},
+		{name => "FBAFormulation",attribute => "FBAFormulation_uuid",parent => "ModelSEED::Store",method=>"FBAFormulation", weak => 0},
 		{name => "referenceMedia",attribute => "referenceMedia_uuid",parent => "Biochemistry",method=>"media"},
 	],
     reference_id_types => [ qw(uuid) ],
@@ -366,11 +369,12 @@ $objectDefinitions->{GapgenSolutionReaction} = {
 };
 
 $objectDefinitions->{GapfillingFormulation} = {
-	parents => ['Model'],
-	class => 'child',
+	parents => ['ModelSEED::Store'],
+	class => 'indexed',
 	attributes => [
 		{name => 'uuid',printOrder => 0,perm => 'rw',type => 'ModelSEED::uuid',req => 0},
-		{name => 'fbaFormulation_uuid',printOrder => 0,perm => 'rw',type => 'ModelSEED::uuid',req => 0},
+		{name => 'FBAFormulation_uuid',printOrder => 0,perm => 'rw',type => 'ModelSEED::uuid',req => 1},
+        {name => 'model_uuid', printOrder => 0, perm => 'rw', type => 'ModelSEED::uuid', req => 1},
 		{name => 'mediaHypothesis',printOrder => 0,perm => 'rw',type => 'Bool',req => 0,default => "0"},
 		{name => 'biomassHypothesis',printOrder => 0,perm => 'rw',type => 'Bool',req => 0,default => "0"},
 		{name => 'gprHypothesis',printOrder => 0,perm => 'rw',type => 'Bool',req => 0,default => "0"},
@@ -397,12 +401,14 @@ $objectDefinitions->{GapfillingFormulation} = {
 	],
 	primarykeys => [ qw(uuid) ],
 	links => [
-		{name => "fbaFormulation",attribute => "fbaFormulation_uuid",parent => "Model",method=>"fbaFormulations"},
+		{name => "FBAFormulation",attribute => "FBAFormulation_uuid",parent => "ModelSEED::Store",method=>"FBAFormulation", weak => 0},
 		{name => "guaranteedReactions",attribute => "guaranteedReaction_uuids",parent => "Biochemistry",method=>"reactions",array => 1},
 		{name => "blacklistedReactions",attribute => "blacklistedReaction_uuids",parent => "Biochemistry",method=>"reactions",array => 1},
-		{name => "allowableCompartments",attribute => "allowableCompartment_uuids",parent => "Biochemistry",method=>"compartments",array => 1}
+		{name => "allowableCompartments",attribute => "allowableCompartment_uuids",parent => "Biochemistry",method=>"compartments",array => 1},
+        {name => "model", attribute => "model_uuid", parent => "ModelSEED::Store", method => "Model", weak => 0},
 	],
     reference_id_types => [ qw(uuid) ],
+    version => 1.0,
 };
 
 $objectDefinitions->{GapfillingGeneCandidate} = {
@@ -1286,18 +1292,15 @@ $objectDefinitions->{Model} = {
 		{name => "modelcompartments",printOrder => 1,class => "ModelCompartment",type => "child"},
 		{name => "modelcompounds",printOrder => 2,class => "ModelCompound",type => "child"},
 		{name => "modelreactions",printOrder => 3,class => "ModelReaction",type => "child"},
-        {name => "fbaFormulations",printOrder => -1,class => "FBAFormulation", type => "child"},
-        {name => "Gapfillingformulations", printOrder => -1, class => "GapfillingFormulation", type => "child"},
 	],
 	primarykeys => [ qw(uuid) ],
 	links => [
 		{name => "biochemistry",attribute => "biochemistry_uuid",parent => "ModelSEED::Store",method=>"Biochemistry", weak => 0},
 		{name => "mapping",attribute => "mapping_uuid",parent => "ModelSEED::Store",method=>"Mapping", weak => 0},
 		{name => "annotation",attribute => "annotation_uuid",parent => "ModelSEED::Store",method=>"Annotation", weak => 0},
-		{name => "modelanalysis",attribute => "modelanalysis_uuid",parent => "ModelSEED::Store",method=>"ModelAnalysis", weak => 0},
 	],
     reference_id_types => [ qw(uuid alias) ],
-    version => 1.0,
+    version => 1.1,
 };
 
 $objectDefinitions->{Biomass} = {


### PR DESCRIPTION
- FBAFormulation and GapfillingFormulation are now top-level
  objects with links back to the Model object.
  - This moves the Model version number up to 1.1. Old gapfilling
    and fba formulation objects in the model are summarily dropped
    on upgrade.
  - gapfill and runfba commands should work properly
- Introduced a flag for runfba and gapfill "--norun" which
  returns the JSON format for the configuration after processing.
