### PR TITLE
Proper error on bad attribute access in ms list

### DIFF
--- a/lib/ModelSEED/App/mseed/Command/list.pm
+++ b/lib/ModelSEED/App/mseed/Command/list.pm
@@ -47,6 +47,7 @@ sub execute {
             # Construct references from alias data
             # TODO: Why isn't this part of Store / Database ?
             my $refs = [
+                  map { ModelSEED::Reference->new( ref => $_ ) }
                   map { $_->{type} . "/" . $_->{owner} . "/" . $_->{alias} }
                   @$aliases
             ];
@@ -104,22 +105,22 @@ sub execute {
 }
 
 sub printForReferences {
-    my ($self, $refstrs, $opts, $store) = @_;
+    my ($self, $refs, $opts, $store) = @_;
     my $need_object = (defined($opts->{with}) || defined($opts->{verbose}));
-    my $columns = $self->determineColumns($refstrs->[0], $opts);
+    my $columns = $self->determineColumns($refs->[0], $opts);
     print join("\t", @$columns) . "\n" if (@$columns > 1);
-    foreach my $refstr (@$refstrs) {
+    foreach my $ref (@$refs) {
         my $o;
         if ($need_object) {
-            $o = $store->get_object($refstr);
+            $o = $store->get_object($ref);
         }
-        print $self->formatOutput($refstr, $o, $columns); 
+        print $self->formatOutput($ref, $o, $columns); 
     }
 }
 
 sub printForData {
     my ($self, $ref, $data, $opts) = @_;
-    my $columns = $self->determineColumns($ref->ref, $opts);
+    my $columns = $self->determineColumns($ref, $opts);
     print join("\t", @$columns) . "\n" if (@$columns > 1);
     foreach my $o (@$data) {
         print $self->formatOutput($ref, $o, $columns);
@@ -128,8 +129,7 @@ sub printForData {
 
 
 sub determineColumns {
-    my ($self, $refstr, $opts) = @_;
-    my $ref = ModelSEED::Reference->new(ref => $refstr);
+    my ($self, $ref, $opts) = @_;
     my $types = $ref->base_types;
     my $type  = $types->[@$types - 1];
     my $with = [ "Reference" ];

--- a/lib/ModelSEED/Exceptions.pm
+++ b/lib/ModelSEED/Exceptions.pm
@@ -57,6 +57,11 @@ use Exception::Class (
         description => "When a bad reference string is passed into a function",
         fields => [qw( refstr )],
     },
+    'ModelSEED::Exception::InvalidAttribute' => {
+        isa => "ModelSEED::Exception::CLI",
+        description => "Error trying to acess an attribute that an object does not have",
+        fields => [qw( object invalid_attribute )],
+    },
 );
 1; 
 
@@ -114,5 +119,21 @@ be whatever you want but cannot contain slashes.
 In the second case, pass in a specific object UUID.
 ND
 } 
+1;
+
+package ModelSEED::Exception::InvalidAttribute;
+sub cli_error_text {
+    my ($self) = shift;
+    my $object = $self->object;
+    my $tried  = $self->invalid_attribute;
+    my $type   = $object->meta->name;
+    my @attrs  = $object->meta->get_all_attributes;
+    my $attr_string = join("\n", map { $_ = "\t".$_->name } @attrs);
+    return <<ND;
+Invalid attribute '$tried' for $type, available attributes:
+$attr_string
+
+ND
+}
 1;
 


### PR DESCRIPTION
- Fixes issue #50: Error message when using with option
- Now passing an invalid attribute to ms list returns
  a CLI error including a list of valid attributes; e.g.

```
$ ms list biochemistry/sdevoid/web/compounds -w idd
Invalid attribute 'idd' for ModelSEED::MS::Compound, available attributes:
        isCofactor
        defaultCharge
        ancestor_uuid
        abstractCompound
        deltaG
        uuid
        mapped_uuid
        pks
        formula
        mass
        modDate
        id
        unchargedFormula
        abstractCompound_uuid
        searchnames
        deltaGErr
        compoundCues
        parent
        name
        cksum
        structures
        comprisedOfCompounds
        comprisedOfCompound_uuids
        abbreviation
```
- Implement new exception 'ModelSEED::Exception::InvalidAttribute'
  where the throw arguments are:

``` perl
ModelSEED::Exception::InvalidAttribute->throw(
    object => $object,
    invalid_attribute => $attr,
);
```

Where `$object` is a `ModelSEED::MS` object and `$attr` is a string.
