### PR TITLE
Fix update for Biochemistry, Model...

### DIFF
--- a/lib/ModelSEED/MS/Biochemistry.pm
+++ b/lib/ModelSEED/MS/Biochemistry.pm
@@ -503,7 +503,6 @@ sub __upgrade__ {
 	if ($version == 1) {
 		return sub {
 			my ($hash) = @_;
-			print "Upgrading biochemistry from v1 to v2!\n";
 			my $bioStruct = ModelSEED::MS::BiochemistryStructures->new({});
 			if (defined($hash->{compounds})) {
 				foreach my $cpd (@{$hash->{compounds}}) {
@@ -620,6 +619,7 @@ sub __upgrade__ {
 				my $parent = $hash->{parent};
 				delete($hash->{parent});
 				$parent->save_data("biochemistry/".$hash->{uuid},$hash,{schema_update => 1});
+                $hash->{parent} = $parent;
 			}
 			return $hash;
 		};

--- a/lib/ModelSEED/MS/Model.pm
+++ b/lib/ModelSEED/MS/Model.pm
@@ -1299,7 +1299,6 @@ sub __upgrade__ {
 	if ($version eq "1") {
 		return sub {
 			my ($hash) = @_;
-			print "Upgrading model from v1 to v2!\n";
 			if (defined($hash->{fbaFormulations})) {
 				delete($hash->{fbaFormulations});
 			}
@@ -1314,6 +1313,7 @@ sub __upgrade__ {
 				my $parent = $hash->{parent};
 				delete($hash->{parent});
 				$parent->save_data("model/".$hash->{uuid},$hash,{schema_update => 1});
+                $hash->{parent} = $parent;
 			}
 			return $hash;
 		};


### PR DESCRIPTION
- Now correctly saves to ModelSEED::Store, preserving link to
  the Store object. I think this addresses the issues in issue #72
- No longer warns "upgrading biochemistry from v1 to v2!", as this
  will probably just confuse the user.
