### PR TITLE
Bash Completion for ModelSEED

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -76,6 +76,7 @@ my $builder = $subclass->new(
         "Graph" => 0,
         "App::Cmd" => 0,
         "autodie" => 0,
+        "Bash::Completion" => 0,
         "Class::Autouse" => 0,
         "Clone" => 0,
         "Config::Tiny" => 0,

--- a/bin/dev-env.sh
+++ b/bin/dev-env.sh
@@ -28,3 +28,4 @@ env_push PATH $SCRIPT_DIR
 export PERL5LIB
 export PATH;
 export MODEL_SEED_CORE=$DIR;
+. setup-bash-complete

--- a/lib/Bash/Completion/Plugins/ModelSEED.pm
+++ b/lib/Bash/Completion/Plugins/ModelSEED.pm
@@ -1,0 +1,98 @@
+########################################################################
+# Bash::Completion::Plugins::ModelSEED
+# Authors: Christopher Henry, Scott Devoid, Paul Frybarger
+# Contact email: chenry@mcs.anl.gov
+# Development locations:
+#   Mathematics and Computer Science Division, Argonne National Lab;
+#   Computation Institute, University of Chicago
+#
+# Date of module creation: 2012-09-13
+########################################################################
+package Bash::Completion::Plugins::ModelSEED;
+use strict;
+use common::sense;
+use Bash::Completion::Utils qw( command_in_path prefix_match );
+use ModelSEED::Bash::Completion::Rules;
+use parent 'Bash::Completion::Plugin';
+
+sub should_activate {
+    if ( command_in_path('ms') )  {
+        return [ qw( ms stores bio mapping genome model ) ];
+    } else {
+        return [];
+    }
+}
+
+our $rules = $ModelSEED::Bash::Completion::Rules::rules;
+sub complete {
+    my ($self, $r) = @_;
+    my @args = $r->args;
+    my ($stateName, $state);
+    while (@args >= 0) {
+        if(!defined $stateName) { 
+            my $curr = shift @args;
+            $stateName = $curr if defined $rules->{$curr};
+            return unless defined $stateName;
+        }
+        $state = $rules->{$stateName};
+        my $newStateName;
+        foreach my $edge (@{$state->{edges}}) {
+            $newStateName = processEdge($edge, \@args);
+            if(defined $newStateName) {
+                $stateName = $newStateName;
+                last;
+            } 
+        }
+        next if $newStateName;
+        my @candidates;
+        #warn "doing completions for $stateName\n";
+        foreach my $completionRule (@{$state->{completions}}) {
+            my @completions = processCompletionRule($completionRule, $r);
+            push(@candidates, @completions);
+
+        }
+        $r->candidates(@candidates);
+        return;
+    }
+}
+
+sub processEdge {
+    my ($edge, $args) = @_;
+    # Array : [ 'exact_match', 'new-state' ]
+    if (ref($edge) eq 'ARRAY') {
+        my $first = $args->[0];
+        if($first eq $edge->[0]) {
+            shift @$args; # consume this arg
+            return $edge->[1];
+        }
+    # Hash : { 'regex' => qr{}, 
+    } elsif (ref($edge) eq 'HASH') {
+        die "TODO";
+    } 
+    return undef;
+}
+
+sub processCompletionRule {
+    my ($rule, $r) = @_;
+    # Rule may be:
+    #     An array, just return these candidates
+    #     A hash, with key "prefix"
+    # 
+    if (ref($rule) eq 'ARRAY') {
+        return prefix_match($r->word, @$rule);
+    }
+    if(ref($rule) eq 'HASH' && defined $rule->{prefix}) {
+        if (defined $rule->{options}) {
+            my $prefix = $rule->{prefix};
+            if($r->word =~ m/^$prefix/) {
+                my @candidates = map { $rule->{prefix} . $_ } @{$rule->{options}}; 
+                return prefix_match($r->word, @candidates);
+            }
+        } elsif(defined($rule->{cmd})) {
+            die "TODO";
+        }
+    }
+    return ();
+}
+
+1;

--- a/lib/ModelSEED/App/mseed/Command/list.pm
+++ b/lib/ModelSEED/App/mseed/Command/list.pm
@@ -14,6 +14,7 @@ use base 'App::Cmd::Command';
 
 
 sub abstract { return "List and retrive objects from workspace or datastore."; }
+sub usage_desc { return "ms list [options] ref" }
 sub opt_spec {
     return (
         ["verbose|v", "Print out additional information about the object, tab-delimited"],
@@ -22,6 +23,20 @@ sub opt_spec {
         ["query|q:s@", "Only list sub objects matching a query"],
         ["help|h|?", "Print this usage information"],
         ["no_ref", "Do not print the reference column (useful for 'with' option)"]
+    );
+}
+sub arg_spec {
+    return (
+        {
+            edges => [],
+            completions => [
+                { "prefix" => "", "options" => [ "biochemistry/", "mapping/", "model/", "annotation/" ] },
+                { "prefix" => "biochemistry/", "cmd" => 'ms list biochemistry' },
+                { "prefix" => "mapping/", "cmd" => 'ms list mapping' },
+                { "prefix" => "model/", "cmd" => 'ms list model' },
+                { "prefix" => "annotation/", "cmd" => 'ms list annotation' },
+            ]
+        }
     );
 }
 

--- a/lib/ModelSEED/Bash/Completion/Rules.pm
+++ b/lib/ModelSEED/Bash/Completion/Rules.pm
@@ -1,0 +1,701 @@
+package ModelSEED::Bash::Completion::Rules;
+our $rules = {
+    'genome_mapping' => {
+        'completions' => [
+            {
+                'options' => [ 'raw', 'full', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'genome_help' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'ms_whoami' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_list' => {
+        'completions' => [
+            {
+                'options' => [ 'verbose', 'mine', 'with', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'mapping' => {
+        'completions' => [ [ 'commands', 'readable', 'bio', 'help' ] ],
+        'edges' => [
+            [ 'commands', 'mapping_commands' ],
+            [ 'readable', 'mapping_readable' ],
+            [ 'bio',      'mapping_bio' ],
+            [ 'help',     'mapping_help' ]
+        ]
+    },
+    'genome_roles' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'bio_validate' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'model_gapgen' => {
+        'completions' => [
+            {
+                'options' => [
+                    'config',           'fbaconfig',
+                    'overwrite',        'save',
+                    'verbose',          'fileout',
+                    'media',            'refmedia',
+                    'notes',            'nomediahyp',
+                    'nobiomasshyp',     'nogprhyp',
+                    'nopathwayhyp',     'objective',
+                    'objfraction',      'rxnko',
+                    'geneko',           'uptakelim',
+                    'defaultmaxflux',   'defaultmaxuptake',
+                    'defaultminuptake', 'help'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'genome_readable' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'model_genome' => {
+        'completions' => [
+            {
+                'options' => [ 'raw', 'full', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'bio_findcpd' => {
+        'completions' => [
+            {
+                'options' => [ 'names', 'filein', 'id', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'bio_addcpd' => {
+        'completions' => [
+            {
+                'options' => [
+                    'abbreviation', 'formula',   'mass',     'charge',
+                    'deltag',       'deltagerr', 'altnames', 'saveas',
+                    'namespace'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'import_mapping' => {
+        'completions' => [
+            {
+                'options' => [
+                    'biochemistry', 'model', 'location', 'store',
+                    'verbose',      'dry',   'help'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'stores_help' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'mapping_bio' => {
+        'completions' => [
+            {
+                'options' => [ 'raw', 'full', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_commands' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'ms_createuser' => {
+        'completions' => [
+            {
+                'options' => [ 'firstname', 'lastname', 'email', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'model_commands' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'genome' => {
+        'completions' => [
+            [
+                'commands',   'roles', 'readable', 'subsystems',
+                'buildmodel', 'help',  'mapping'
+            ]
+        ],
+        'edges' => [
+            [ 'commands',   'genome_commands' ],
+            [ 'roles',      'genome_roles' ],
+            [ 'readable',   'genome_readable' ],
+            [ 'subsystems', 'genome_subsystems' ],
+            [ 'buildmodel', 'genome_buildmodel' ],
+            [ 'help',       'genome_help' ],
+            [ 'mapping',    'genome_mapping' ]
+        ]
+    },
+    'ms_logout' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms' => {
+        'completions' => [
+            [
+                'list',       'commands', 'mapping', 'config',
+                'genome',     'get',      'revert',  'defaults',
+                'import',     'error',    'whoami',  'history',
+                'save',       'model',    'pp',      'stores',
+                'help',       'login',    'bio',     'logout',
+                'createuser', 'update'
+            ]
+        ],
+        'edges' => [
+            [ 'list',       'ms_list' ],
+            [ 'commands',   'ms_commands' ],
+            [ 'mapping',    'mapping' ],
+            [ 'config',     'ms_config' ],
+            [ 'genome',     'genome' ],
+            [ 'get',        'ms_get' ],
+            [ 'revert',     'ms_revert' ],
+            [ 'defaults',   'ms_defaults' ],
+            [ 'import',     'import' ],
+            [ 'error',      'ms_error' ],
+            [ 'whoami',     'ms_whoami' ],
+            [ 'history',    'ms_history' ],
+            [ 'save',       'ms_save' ],
+            [ 'model',      'model' ],
+            [ 'pp',         'ms_pp' ],
+            [ 'stores',     'stores' ],
+            [ 'help',       'ms_help' ],
+            [ 'login',      'ms_login' ],
+            [ 'bio',        'bio' ],
+            [ 'logout',     'ms_logout' ],
+            [ 'createuser', 'ms_createuser' ],
+            [ 'update',     'ms_update' ]
+        ]
+    },
+    'bio_aliasset' => {
+        'completions' => [
+            {
+                'options' => [
+                    'validate', 'list',    'store', 'verbose',
+                    'dry',      'mapping', 'help'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'model_simphenotypes' => {
+        'completions' => [
+            {
+                'options' => [
+                    'save',             'saveas',
+                    'verbose',          'notes',
+                    'objective',        'rxnko',
+                    'geneko',           'uptakelim',
+                    'defaultmaxflux',   'defaultmaxuptake',
+                    'defaultminuptake', 'help'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'stores_list' => {
+        'completions' => [
+            {
+                'options' => [ 'verbose', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'genome_buildmodel' => {
+        'completions' => [
+            {
+                'options' => [ 'mapping', 'verbose', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'bio_readable' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_defaults' => {
+        'completions' => [
+            {
+                'options' => [ 'set', 'unset', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_help' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'ms_pp' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_revert' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'model_sbml' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'import_annotation' => {
+        'completions' => [
+            {
+                'options' => [
+                    'list', 'source',  'store', 'verbose',
+                    'dry',  'mapping', 'help'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'bio_help' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'mapping_help' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'model' => {
+        'completions' => [
+            [
+                'gapfill',  'runfba',        'commands', 'genome',
+                'readable', 'calcdistances', 'tohtml',   'simphenotypes',
+                'help',     'gapgen',        'sbml'
+            ]
+        ],
+        'edges' => [
+            [ 'gapfill',       'model_gapfill' ],
+            [ 'runfba',        'model_runfba' ],
+            [ 'commands',      'model_commands' ],
+            [ 'genome',        'model_genome' ],
+            [ 'readable',      'model_readable' ],
+            [ 'calcdistances', 'model_calcdistances' ],
+            [ 'tohtml',        'model_tohtml' ],
+            [ 'simphenotypes', 'model_simphenotypes' ],
+            [ 'help',          'model_help' ],
+            [ 'gapgen',        'model_gapgen' ],
+            [ 'sbml',          'model_sbml' ]
+        ]
+    },
+    'stores' => {
+        'completions' =>
+          [ [ 'prioritize', 'add', 'commands', 'rm', 'help', 'list' ] ],
+        'edges' => [
+            [ 'prioritize', 'stores_prioritize' ],
+            [ 'add',        'stores_add' ],
+            [ 'commands',   'stores_commands' ],
+            [ 'rm',         'stores_rm' ],
+            [ 'help',       'stores_help' ],
+            [ 'list',       'stores_list' ]
+        ]
+    },
+    'stores_rm' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'bio' => {
+        'completions' => [
+            [
+                'commands',      'validate',
+                'addcpd',        'addcpdtable',
+                'calcdistances', 'create',
+                'addrxntable',   'addrxn',
+                'help',          'findcpd',
+                'aliasset',      'readable'
+            ]
+        ],
+        'edges' => [
+            [ 'commands',      'bio_commands' ],
+            [ 'validate',      'bio_validate' ],
+            [ 'addcpd',        'bio_addcpd' ],
+            [ 'addcpdtable',   'bio_addcpdtable' ],
+            [ 'calcdistances', 'bio_calcdistances' ],
+            [ 'create',        'bio_create' ],
+            [ 'addrxntable',   'bio_addrxntable' ],
+            [ 'addrxn',        'bio_addrxn' ],
+            [ 'help',          'bio_help' ],
+            [ 'findcpd',       'bio_findcpd' ],
+            [ 'aliasset',      'bio_aliasset' ],
+            [ 'readable',      'bio_readable' ]
+        ]
+    },
+    'bio_create' => {
+        'completions' => [
+            {
+                'options' => [ 'namespace', 'verbose' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'bio_addrxn' => {
+        'completions' => [
+            {
+                'options' => [
+                    'names',  'abbreviation', 'enzymes', 'direction',
+                    'deltag', 'deltagerr',    'saveas',  'namespace'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'mapping_readable' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'stores_add' => {
+        'completions' => [
+            {
+                'options' => [
+                    'type',     'help', 'db_name', 'password',
+                    'username', 'host', 'directory'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_update' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'ms_login' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_config' => {
+        'completions' => [
+            {
+                'options' => [ 'list', 'remove', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'bio_addrxntable' => {
+        'completions' => [
+            {
+                'options' => [ 'saveas', 'namespace', 'autoadd' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_history' => {
+        'completions' => [
+            {
+                'options' => [ 'date', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_get' => {
+        'completions' => [
+            {
+                'options' => [ 'file', 'pretty', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'model_gapfill' => {
+        'completions' => [
+            {
+                'options' => [
+                    'config',           'fbaconfig',
+                    'overwrite',        'save',
+                    'verbose',          'fileout',
+                    'media',            'notes',
+                    'objective',        'nomediahyp',
+                    'nobiomasshyp',     'nogprhyp',
+                    'nopathwayhyp',     'allowunbalanced',
+                    'activitybonus',    'drainpen',
+                    'directionpen',     'nostructpen',
+                    'unfavorablepen',   'nodeltagpen',
+                    'biomasstranspen',  'singletranspen',
+                    'transpen',         'blacklistedrxns',
+                    'gauranteedrxns',   'allowedcmps',
+                    'objfraction',      'rxnko',
+                    'geneko',           'uptakelim',
+                    'defaultmaxflux',   'defaultmaxuptake',
+                    'defaultminuptake', 'help'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'stores_prioritize' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'stores_commands' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'model_tohtml' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'import_biochemistry' => {
+        'completions' => [
+            {
+                'options' =>
+                  [ 'location', 'model', 'store', 'verbose', 'dry', 'help' ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'model_readable' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'genome_commands' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'bio_calcdistances' => {
+        'completions' => [
+            {
+                'options' =>
+                  [ 'verbose', 'reactions', 'roles', 'matrix', 'threshold' ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'import_model' => {
+        'completions' => [
+            {
+                'options' => [
+                    'list',    'source', 'annotation', 'store',
+                    'verbose', 'dry',    'help'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_error' => {
+        'completions' => [
+            {
+                'options' => [ 'list', 'verbose', 'help' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'import_help' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'model_runfba' => {
+        'completions' => [
+            {
+                'options' => [
+                    'config',            'overwrite',
+                    'save',              'verbose',
+                    'fileout',           'media',
+                    'notes',             'objective',
+                    'objfraction',       'rxnko',
+                    'geneko',            'uptakelim',
+                    'defaultmaxflux',    'defaultmaxuptake',
+                    'defaultminuptake',  'fva',
+                    'simulateko',        'minimizeflux',
+                    'findminmedia',      'allreversible',
+                    'simplethermoconst', 'thermoconst',
+                    'nothermoerror',     'minthermoerror',
+                    'html',              'help'
+                ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'import' => {
+        'completions' => [
+            [
+                'annotation', 'commands', 'model', 'mapping',
+                'help',       'biochemistry'
+            ]
+        ],
+        'edges' => [
+            [ 'annotation',   'import_annotation' ],
+            [ 'commands',     'import_commands' ],
+            [ 'model',        'import_model' ],
+            [ 'mapping',      'import_mapping' ],
+            [ 'help',         'import_help' ],
+            [ 'biochemistry', 'import_biochemistry' ]
+        ]
+    },
+    'mapping_commands' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'model_help' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'genome_subsystems' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'bio_commands' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'import_commands' => {
+        'completions' => [],
+        'edges'       => []
+    },
+    'model_calcdistances' => {
+        'completions' => [
+            {
+                'options' =>
+                  [ 'verbose', 'reactions', 'roles', 'matrix', 'threshold' ],
+                'prefix' => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'ms_save' => {
+        'completions' => [
+            {
+                'options' => ['help'],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    },
+    'bio_addcpdtable' => {
+        'completions' => [
+            {
+                'options' => [ 'saveas', 'namespace' ],
+                'prefix'  => '--'
+            }
+        ],
+        'edges' => []
+    }
+};
+1;

--- a/lib/ModelSEED/Bash/Completion/Rules.pm
+++ b/lib/ModelSEED/Bash/Completion/Rules.pm
@@ -1,5 +1,27 @@
+
+=head1 ModelSEED::Bash::Completion::Rules
+
+Rules for performing bash-completion steps. This
+package is consumed by L<Bash::Completion::Plugin::ModelSEED>
+THIS IS AN AUTOMATICALLY GENERATED PACKAGE. DO NOT EDIT. See
+Rebuilding for instructions to regenerate this package.
+
+=head2 rules
+
+This function returns the bash completion rules.
+
+=head2 Rebuilding
+
+See scripts/generateBashCompletionRules for instructions
+on rebuilding this module.
+
+=cut
+
 package ModelSEED::Bash::Completion::Rules;
-our $rules = {
+use strict;
+use warnings;
+
+our $RULES = {
     'genome_mapping' => {
         'completions' => [
             {
@@ -719,4 +741,9 @@ our $rules = {
         'edges' => []
     }
 };
+
+sub rules {
+    return $RULES;
+}
 1;
+

--- a/lib/ModelSEED/Bash/Completion/Rules.pm
+++ b/lib/ModelSEED/Bash/Completion/Rules.pm
@@ -16,7 +16,7 @@ our $rules = {
     'ms_whoami' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -27,6 +27,27 @@ our $rules = {
             {
                 'options' => [ 'verbose', 'mine', 'with', 'help' ],
                 'prefix'  => '--'
+            },
+            {
+                'options' =>
+                  [ 'biochemistry/', 'mapping/', 'model/', 'annotation/' ],
+                'prefix' => ''
+            },
+            {
+                'cmd'    => 'ms list biochemistry',
+                'prefix' => 'biochemistry/'
+            },
+            {
+                'cmd'    => 'ms list mapping',
+                'prefix' => 'mapping/'
+            },
+            {
+                'cmd'    => 'ms list model',
+                'prefix' => 'model/'
+            },
+            {
+                'cmd'    => 'ms list annotation',
+                'prefix' => 'annotation/'
             }
         ],
         'edges' => []
@@ -43,7 +64,7 @@ our $rules = {
     'genome_roles' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -52,7 +73,7 @@ our $rules = {
     'bio_validate' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -82,7 +103,7 @@ our $rules = {
     'genome_readable' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -181,7 +202,7 @@ our $rules = {
     'ms_logout' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -272,7 +293,7 @@ our $rules = {
     'bio_readable' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -294,7 +315,7 @@ our $rules = {
     'ms_pp' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -303,7 +324,7 @@ our $rules = {
     'ms_revert' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -312,7 +333,7 @@ our $rules = {
     'model_sbml' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -375,7 +396,7 @@ our $rules = {
     'stores_rm' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -431,7 +452,7 @@ our $rules = {
     'mapping_readable' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -456,7 +477,7 @@ our $rules = {
     'ms_login' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -528,7 +549,7 @@ our $rules = {
     'stores_prioritize' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -541,7 +562,7 @@ our $rules = {
     'model_tohtml' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -560,7 +581,7 @@ our $rules = {
     'model_readable' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -655,7 +676,7 @@ our $rules = {
     'genome_subsystems' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],
@@ -682,7 +703,7 @@ our $rules = {
     'ms_save' => {
         'completions' => [
             {
-                'options' => ['help'],
+                'options' => [ 'help' ],
                 'prefix'  => '--'
             }
         ],

--- a/scripts/generateBashCompletionRules.pl
+++ b/scripts/generateBashCompletionRules.pl
@@ -1,0 +1,160 @@
+#!/usr/bin/perl 
+use strict;
+use warnings;
+use Module::Load;
+use Test::More tests => 4;
+use Test::Deep;
+use JSON::XS;
+use Data::Dumper;
+
+my %topLevelCommands = qw(
+    ms ModelSEED::App::mseed
+    stores ModelSEED::App::stores
+    bio ModelSEED::App::bio
+    mapping ModelSEED::App::mapping
+    genome ModelSEED::App::genome
+    model ModelSEED::App::model
+);
+my %innerCommands = qw(
+    import ModelSEED::App::import
+);
+
+my %linkedCommands = qw(
+    ms import
+    ms stores
+    ms bio
+    ms mapping
+    ms genome
+    ms model
+);
+my $linkedCommands = {
+    ms => {
+        map { $_ => 1 } qw( import stores bio mapping genome model )
+    },
+};
+
+
+sub process_app {
+    my ($states, $app, $app_pkg, $linked_app_cmds) = @_;
+    load $app_pkg;
+    my @plugins = $app_pkg->command_plugins;
+    my ($edges, $completions) = ( [], [] );
+    my $basic_completion = [];
+    my $state = { edges => $edges, completions => $completions };
+    foreach my $cmd_pkg (@plugins) {
+        my @commands = $cmd_pkg->command_names;
+        my $command = $commands[0];
+        if(defined $linked_app_cmds->{$app}->{$command}) {
+            push(@$edges, [ $command, "$command" ]);
+            push(@$basic_completion, $command);
+        } else {
+            my $command_state = "${app}_$command";
+            push(@$edges, [ $command, $command_state] );
+            push(@$basic_completion, $command);
+            process_command($states, $app, $command, $app_pkg, $cmd_pkg);
+        }
+    }
+    if(@$basic_completion) {
+        push(@$completions, $basic_completion);
+    }
+    $states->{$app} = $state;
+}
+
+sub process_command {
+    my ($states, $app, $cmd, $app_pkg, $cmd_pkg) = @_;
+    my $state_name = "${app}_$cmd";
+    my ($edges, $completions) = ( [], [] );
+    my $state = { edges => $edges, completions => $completions };
+    # do options
+    my @options = $cmd_pkg->opt_spec;
+    my $option_completions = [];
+    my $simple_completions = [];
+    foreach my $option (@options) {
+        my $str = $option->[0];
+        # If we consume an additional arg
+        if ($str =~ m/[:=]/) {
+            my ($keys, $type) = split(/[:=]/, $str); 
+            my @keys = split(/\|/, $keys);
+            push(@$option_completions, $keys[0]);
+            # do command_option sub-state 
+        } else {
+            my @keys = split(/\|/, $str);
+            push(@$option_completions, $keys[0]);
+        }
+    }
+    if(@$simple_completions != 0) {
+        push(@$completions, $simple_completions);
+    }
+    if(@$option_completions != 0) {
+        push(@$completions, { "prefix" => "--", "options" => $option_completions });
+    }
+    $states->{$state_name} = $state;
+}
+
+my $states = {};
+foreach my $cmd ( keys %topLevelCommands) {
+    my $pkg = $topLevelCommands{$cmd};
+    process_app($states, $cmd, $pkg, $linkedCommands);
+}
+foreach my $cmd ( keys %innerCommands) {
+    my $pkg = $innerCommands{$cmd};
+    process_app($states, $cmd, $pkg, $linkedCommands);
+}
+
+print Dumper $states;
+
+=head3 fsm
+
+    [
+        "ms" : {
+            "edges" : [
+                [ "stores", "stores" ],
+                [ "bio", "bio" ]
+                [ "list", "ms_list" ],
+             ],
+             "completions" : [
+                [ "stores" , "bio", "foo", "biochemistry" ],
+                { "prefix" : "biochemistry", "cmd" : 'ms list biochemistry' },
+        },
+        "ms_list" : {
+            "edges" : [
+                [ "-w", "ms_list--with" ],
+            ],
+            "completions" : [
+                [ "--with", "--help", "--no_ref" ],
+                { "prefix" : "", "options" : [ "biochemistry/", "mapping/", "model/", "annotation/" ] },
+                { "prefix" : "biochemistry/", "cmd" : 'ms list biochemistry' }
+            ],
+        },
+        "ms_list--with" : {
+            "edges" : [
+                { "regex" : "m/.+\s/", "to" : "ms_list", "c" : 1 }
+            ],
+            "completions" : []
+        }
+}
+
+# edges : an array of edge, iterate through all until match one
+#     edge may be :
+#         an array where 0 is an exeact string to match, 1 is the state to jump to, consume 1.
+#         a hash :
+#             "has key regex" : match on regex, go to "to" node, consuming "c" args
+#   
+# completions : an array of completion generators, return the subset of all that prefix-match:
+#      a completion generator may be :
+#          an array, just return that shit
+#          a hash :
+#              "has key prefix" : if we match on prefix, then...
+#                   "has key options" : add the array of options to the set to match against (useful?)
+#                   "has key cmd" : run this command and include the results in the match set
+
+# doing top-level :
+#     state name is cmd
+#     edges : subcommands "cmd_subcommand"
+#           if subcommand simply "redirects" to top-level command... edge is cmd
+#     completions : top-level options, subcommands
+
+# doing subcommands:
+#     state name is cmd_subcommand
+#     edges : option with string
+#     completions : options, argument generators

--- a/scripts/generateBashCompletionRules.pl
+++ b/scripts/generateBashCompletionRules.pl
@@ -6,6 +6,7 @@ use Test::More tests => 4;
 use Test::Deep;
 use JSON::XS;
 use Data::Dumper;
+use Try::Tiny;
 
 my %topLevelCommands = qw(
     ms ModelSEED::App::mseed
@@ -87,6 +88,16 @@ sub process_command {
     }
     if(@$option_completions != 0) {
         push(@$completions, { "prefix" => "--", "options" => $option_completions });
+    }
+    # do arguments
+    my @arg_states;
+    try {
+        @arg_states = $cmd_pkg->arg_spec();
+    };
+    for(my $i=0; $i<@arg_states; $i++) {
+        # for now, just push completions onto this state's completions
+        my $arg_state = $arg_states[$i];
+        push(@$completions, @{$arg_state->{completions}});
     }
     $states->{$state_name} = $state;
 }

--- a/t/bash-completion.t
+++ b/t/bash-completion.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+use Bash::Completion::Plugin::Test;
+use Test::More tests => 2;
+
+my $tester = Bash::Completion::Plugin::Test->new(
+    plugin => 'Bash::Completion::Plugins::ModelSEED',
+);
+
+$tester->check_completions('ms imp^', [qw( import )]);
+$tester->check_completions('ms lo^', [qw( logout login )]);
+


### PR DESCRIPTION
- script generateBashCompletionRules that generates
  rules for bash completion. These are put into the
  module:
- ModelSEED::Bash::Completion::Rules, a module with
  rules for doing bash completion. This is read in
  by the bash completion plugin:
- Bash::Completion::Plugins::ModelSEED, a plugin
  that is initialized by the Bash::Completion stuff.

To use, add `source setup-bash-complete` to your
.bashrc or .bash_profile...

TODO :
- implement options that consume args, e.g. --with foo
- implement completion for arguments, e.g. ms list <TAB>
- more unit tests, figure out how to do this properly
