### PR TITLE
Fix issue with abstractCompound being undefined

### DIFF
--- a/lib/ModelSEED/MS/BaseObject.pm
+++ b/lib/ModelSEED/MS/BaseObject.pm
@@ -604,14 +604,15 @@ sub getLinkedObject {
         }
         $object = $sourceObj->getObject($attribute,$uuid);
         return $object if defined $object;
-        ModelSEED::Exception::BadObjectLink->throw(
-            searchSource     => $self,
-            searchBaseObject => $sourceObj,
-            searchBaseType   => $sourceType,
-            searchAttribute  => $attribute,
-            searchUUID       => $uuid,
-            errorText        => 'No object found with that UUID',
-        );
+#        ModelSEED::Exception::BadObjectLink->throw(
+#            searchSource     => $self,
+#            searchBaseObject => $sourceObj,
+#            searchBaseType   => $sourceType,
+#            searchAttribute  => $attribute,
+#            searchUUID       => $uuid,
+#            errorText        => 'No object found with that UUID',
+#        );
+        return;
     }
 }
 

--- a/lib/ModelSEED/MS/DB/Annotation.pm
+++ b/lib/ModelSEED/MS/DB/Annotation.pm
@@ -39,7 +39,7 @@ has subsystemStates => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub {
 
 
 # LINKS:
-has mapping => (is => 'rw', isa => 'ModelSEED::MS::Mapping', type => 'link(ModelSEED::Store,Mapping,mapping_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_mapping', clearer => 'clear_mapping');
+has mapping => (is => 'rw', type => 'link(ModelSEED::Store,Mapping,mapping_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_mapping', clearer => 'clear_mapping', isa => 'ModelSEED::MS::Mapping');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/Biochemistry.pm
+++ b/lib/ModelSEED/MS/DB/Biochemistry.pm
@@ -49,7 +49,7 @@ has cues => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { return [];
 
 
 # LINKS:
-has biochemistrystructures => (is => 'rw', isa => 'ModelSEED::MS::BiochemistryStructures', type => 'link(ModelSEED::Store,BiochemistryStructures,biochemistryStructures_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_biochemistrystructures', clearer => 'clear_biochemistrystructures');
+has biochemistrystructures => (is => 'rw', type => 'link(ModelSEED::Store,BiochemistryStructures,biochemistryStructures_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_biochemistrystructures', clearer => 'clear_biochemistrystructures', isa => 'ModelSEED::MS::BiochemistryStructures');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/BiomassCompound.pm
+++ b/lib/ModelSEED/MS/DB/BiomassCompound.pm
@@ -21,7 +21,7 @@ has coefficient => (is => 'rw', isa => 'Num', printOrder => '0', required => 1, 
 
 
 # LINKS:
-has modelcompound => (is => 'rw', isa => 'ModelSEED::MS::ModelCompound', type => 'link(Model,modelcompounds,modelcompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelcompound', clearer => 'clear_modelcompound', weak_ref => 1);
+has modelcompound => (is => 'rw', type => 'link(Model,modelcompounds,modelcompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelcompound', clearer => 'clear_modelcompound', isa => 'ModelSEED::MS::ModelCompound', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/BiomassTemplateComponent.pm
+++ b/lib/ModelSEED/MS/DB/BiomassTemplateComponent.pm
@@ -30,7 +30,7 @@ has ancestor_uuid => (is => 'rw', isa => 'uuid', type => 'ancestor', metaclass =
 
 
 # LINKS:
-has compound => (is => 'rw', isa => 'ModelSEED::MS::Compound', type => 'link(Biochemistry,compounds,compound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compound', clearer => 'clear_compound', weak_ref => 1);
+has compound => (is => 'rw', type => 'link(Biochemistry,compounds,compound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compound', clearer => 'clear_compound', isa => 'ModelSEED::MS::Compound', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/Complex.pm
+++ b/lib/ModelSEED/MS/DB/Complex.pm
@@ -32,7 +32,7 @@ has complexroles => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { re
 
 
 # LINKS:
-has reactions => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Reaction]', type => 'link(Biochemistry,reactions,reaction_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_reactions', clearer => 'clear_reactions');
+has reactions => (is => 'rw', type => 'link(Biochemistry,reactions,reaction_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_reactions', clearer => 'clear_reactions', isa => 'ArrayRef[ModelSEED::MS::Reaction]');
 has id => (is => 'rw', lazy => 1, builder => '_build_id', isa => 'Str', type => 'id', metaclass => 'Typed');
 
 

--- a/lib/ModelSEED/MS/DB/ComplexRole.pm
+++ b/lib/ModelSEED/MS/DB/ComplexRole.pm
@@ -23,7 +23,7 @@ has triggering => (is => 'rw', isa => 'Int', printOrder => '0', default => '1', 
 
 
 # LINKS:
-has role => (is => 'rw', isa => 'ModelSEED::MS::Role', type => 'link(Mapping,roles,role_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_role', clearer => 'clear_role', weak_ref => 1);
+has role => (is => 'rw', type => 'link(Mapping,roles,role_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_role', clearer => 'clear_role', isa => 'ModelSEED::MS::Role', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/Compound.pm
+++ b/lib/ModelSEED/MS/DB/Compound.pm
@@ -41,9 +41,9 @@ has ancestor_uuid => (is => 'rw', isa => 'uuid', type => 'ancestor', metaclass =
 
 
 # LINKS:
-has abstractCompound => (is => 'rw', isa => 'ModelSEED::MS::Compound', type => 'link(Biochemistry,compounds,abstractCompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_abstractCompound', clearer => 'clear_abstractCompound', weak_ref => 1);
-has comprisedOfCompounds => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Compound]', type => 'link(Biochemistry,compounds,comprisedOfCompound_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_comprisedOfCompounds', clearer => 'clear_comprisedOfCompounds');
-has structures => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Structure]', type => 'link(BiochemistryStructures,structures,structure_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_structures', clearer => 'clear_structures');
+has abstractCompound => (is => 'rw', type => 'link(Biochemistry,compounds,abstractCompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_abstractCompound', clearer => 'clear_abstractCompound', isa => 'Maybe[ModelSEED::MS::Compound]', weak_ref => 1);
+has comprisedOfCompounds => (is => 'rw', type => 'link(Biochemistry,compounds,comprisedOfCompound_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_comprisedOfCompounds', clearer => 'clear_comprisedOfCompounds', isa => 'ArrayRef[ModelSEED::MS::Compound]');
+has structures => (is => 'rw', type => 'link(BiochemistryStructures,structures,structure_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_structures', clearer => 'clear_structures', isa => 'ArrayRef[ModelSEED::MS::Structure]');
 has id => (is => 'rw', lazy => 1, builder => '_build_id', isa => 'Str', type => 'id', metaclass => 'Typed');
 
 
@@ -244,7 +244,8 @@ my $links = [
             'clearer' => 'clear_abstractCompound',
             'name' => 'abstractCompound',
             'class' => 'compounds',
-            'method' => 'compounds'
+            'method' => 'compounds',
+            'can_be_undef' => 1
           },
           {
             'array' => 1,

--- a/lib/ModelSEED/MS/DB/CompoundSet.pm
+++ b/lib/ModelSEED/MS/DB/CompoundSet.pm
@@ -30,7 +30,7 @@ has ancestor_uuid => (is => 'rw', isa => 'uuid', type => 'ancestor', metaclass =
 
 
 # LINKS:
-has compounds => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Compound]', type => 'link(Biochemistry,compounds,compound_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_compounds', clearer => 'clear_compounds');
+has compounds => (is => 'rw', type => 'link(Biochemistry,compounds,compound_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_compounds', clearer => 'clear_compounds', isa => 'ArrayRef[ModelSEED::MS::Compound]');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/Cue.pm
+++ b/lib/ModelSEED/MS/DB/Cue.pm
@@ -37,7 +37,7 @@ has ancestor_uuid => (is => 'rw', isa => 'uuid', type => 'ancestor', metaclass =
 
 
 # LINKS:
-has structure => (is => 'rw', isa => 'ModelSEED::MS::Structure', type => 'link(BiochemistryStructures,structures,structure_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_structure', clearer => 'clear_structure', weak_ref => 1);
+has structure => (is => 'rw', type => 'link(BiochemistryStructures,structures,structure_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_structure', clearer => 'clear_structure', isa => 'ModelSEED::MS::Structure', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBABiomassVariable.pm
+++ b/lib/ModelSEED/MS/DB/FBABiomassVariable.pm
@@ -27,7 +27,7 @@ has value => (is => 'rw', isa => 'Num', printOrder => '6', type => 'attribute', 
 
 
 # LINKS:
-has biomass => (is => 'rw', isa => 'ModelSEED::MS::Biomass', type => 'link(Model,biomasses,biomass_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_biomass', clearer => 'clear_biomass', weak_ref => 1);
+has biomass => (is => 'rw', type => 'link(Model,biomasses,biomass_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_biomass', clearer => 'clear_biomass', isa => 'ModelSEED::MS::Biomass', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBACompoundBound.pm
+++ b/lib/ModelSEED/MS/DB/FBACompoundBound.pm
@@ -23,7 +23,7 @@ has lowerBound => (is => 'rw', isa => 'Num', printOrder => '-1', required => 1, 
 
 
 # LINKS:
-has modelCompound => (is => 'rw', isa => 'ModelSEED::MS::ModelCompound', type => 'link(Model,modelcompounds,modelcompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelCompound', clearer => 'clear_modelCompound', weak_ref => 1);
+has modelCompound => (is => 'rw', type => 'link(Model,modelcompounds,modelcompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelCompound', clearer => 'clear_modelCompound', isa => 'ModelSEED::MS::ModelCompound', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBACompoundVariable.pm
+++ b/lib/ModelSEED/MS/DB/FBACompoundVariable.pm
@@ -27,7 +27,7 @@ has value => (is => 'rw', isa => 'Num', printOrder => '6', type => 'attribute', 
 
 
 # LINKS:
-has modelcompound => (is => 'rw', isa => 'ModelSEED::MS::ModelCompound', type => 'link(Model,modelcompounds,modelcompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelcompound', clearer => 'clear_modelcompound', weak_ref => 1);
+has modelcompound => (is => 'rw', type => 'link(Model,modelcompounds,modelcompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelcompound', clearer => 'clear_modelcompound', isa => 'ModelSEED::MS::ModelCompound', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBADeletionResult.pm
+++ b/lib/ModelSEED/MS/DB/FBADeletionResult.pm
@@ -21,7 +21,7 @@ has growthFraction => (is => 'rw', isa => 'Num', printOrder => '1', required => 
 
 
 # LINKS:
-has genekos => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Feature]', type => 'link(Annotation,features,geneko_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_genekos', clearer => 'clear_genekos');
+has genekos => (is => 'rw', type => 'link(Annotation,features,geneko_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_genekos', clearer => 'clear_genekos', isa => 'ArrayRef[ModelSEED::MS::Feature]');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBAFormulation.pm
+++ b/lib/ModelSEED/MS/DB/FBAFormulation.pm
@@ -71,11 +71,11 @@ has fbaPhenotypeSimulations => (is => 'rw', isa => 'ArrayRef[HashRef]', default 
 
 
 # LINKS:
-has model => (is => 'rw', isa => 'ModelSEED::MS::Model', type => 'link(ModelSEED::Store,Model,model_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_model', clearer => 'clear_model');
-has media => (is => 'rw', isa => 'ModelSEED::MS::Media', type => 'link(Biochemistry,media,media_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_media', clearer => 'clear_media', weak_ref => 1);
-has geneKOs => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Feature]', type => 'link(Annotation,features,geneKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_geneKOs', clearer => 'clear_geneKOs');
-has reactionKOs => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Reaction]', type => 'link(Biochemistry,reactions,reactionKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_reactionKOs', clearer => 'clear_reactionKOs');
-has secondaryMedia => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Media]', type => 'link(Biochemistry,media,secondaryMedia_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_secondaryMedia', clearer => 'clear_secondaryMedia');
+has model => (is => 'rw', type => 'link(ModelSEED::Store,Model,model_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_model', clearer => 'clear_model', isa => 'ModelSEED::MS::Model');
+has media => (is => 'rw', type => 'link(Biochemistry,media,media_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_media', clearer => 'clear_media', isa => 'ModelSEED::MS::Media', weak_ref => 1);
+has geneKOs => (is => 'rw', type => 'link(Annotation,features,geneKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_geneKOs', clearer => 'clear_geneKOs', isa => 'ArrayRef[ModelSEED::MS::Feature]');
+has reactionKOs => (is => 'rw', type => 'link(Biochemistry,reactions,reactionKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_reactionKOs', clearer => 'clear_reactionKOs', isa => 'ArrayRef[ModelSEED::MS::Reaction]');
+has secondaryMedia => (is => 'rw', type => 'link(Biochemistry,media,secondaryMedia_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_secondaryMedia', clearer => 'clear_secondaryMedia', isa => 'ArrayRef[ModelSEED::MS::Media]');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBAMetaboliteProductionResult.pm
+++ b/lib/ModelSEED/MS/DB/FBAMetaboliteProductionResult.pm
@@ -21,7 +21,7 @@ has maximumProduction => (is => 'rw', isa => 'Num', printOrder => '3', required 
 
 
 # LINKS:
-has modelCompound => (is => 'rw', isa => 'ModelSEED::MS::ModelCompound', type => 'link(Model,modelcompounds,modelCompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelCompound', clearer => 'clear_modelCompound', weak_ref => 1);
+has modelCompound => (is => 'rw', type => 'link(Model,modelcompounds,modelCompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelCompound', clearer => 'clear_modelCompound', isa => 'ModelSEED::MS::ModelCompound', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBAMinimalMediaResult.pm
+++ b/lib/ModelSEED/MS/DB/FBAMinimalMediaResult.pm
@@ -22,9 +22,9 @@ has optionalNutrient_uuids => (is => 'rw', isa => 'ArrayRef', printOrder => '-1'
 
 
 # LINKS:
-has minimalMedia => (is => 'rw', isa => 'ModelSEED::MS::Media', type => 'link(Biochemistry,media,minimalMedia_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_minimalMedia', clearer => 'clear_minimalMedia', weak_ref => 1);
-has essentialNutrients => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Compound]', type => 'link(Biochemistry,compounds,essentialNutrient_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_essentialNutrients', clearer => 'clear_essentialNutrients');
-has optionalNutrients => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Compound]', type => 'link(Biochemistry,compounds,optionalNutrient_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_optionalNutrients', clearer => 'clear_optionalNutrients');
+has minimalMedia => (is => 'rw', type => 'link(Biochemistry,media,minimalMedia_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_minimalMedia', clearer => 'clear_minimalMedia', isa => 'ModelSEED::MS::Media', weak_ref => 1);
+has essentialNutrients => (is => 'rw', type => 'link(Biochemistry,compounds,essentialNutrient_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_essentialNutrients', clearer => 'clear_essentialNutrients', isa => 'ArrayRef[ModelSEED::MS::Compound]');
+has optionalNutrients => (is => 'rw', type => 'link(Biochemistry,compounds,optionalNutrient_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_optionalNutrients', clearer => 'clear_optionalNutrients', isa => 'ArrayRef[ModelSEED::MS::Compound]');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBAPhenotypeSimulation.pm
+++ b/lib/ModelSEED/MS/DB/FBAPhenotypeSimulation.pm
@@ -32,10 +32,10 @@ has ancestor_uuid => (is => 'rw', isa => 'uuid', type => 'ancestor', metaclass =
 
 
 # LINKS:
-has media => (is => 'rw', isa => 'ModelSEED::MS::Media', type => 'link(Biochemistry,media,media_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_media', clearer => 'clear_media', weak_ref => 1);
-has geneKOs => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Feature]', type => 'link(Annotation,features,geneKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_geneKOs', clearer => 'clear_geneKOs');
-has reactionKOs => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Reaction]', type => 'link(Biochemistry,reactions,reactionKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_reactionKOs', clearer => 'clear_reactionKOs');
-has additionalCpds => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Compound]', type => 'link(Biochemistry,compounds,additionalCpd_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_additionalCpds', clearer => 'clear_additionalCpds');
+has media => (is => 'rw', type => 'link(Biochemistry,media,media_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_media', clearer => 'clear_media', isa => 'ModelSEED::MS::Media', weak_ref => 1);
+has geneKOs => (is => 'rw', type => 'link(Annotation,features,geneKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_geneKOs', clearer => 'clear_geneKOs', isa => 'ArrayRef[ModelSEED::MS::Feature]');
+has reactionKOs => (is => 'rw', type => 'link(Biochemistry,reactions,reactionKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_reactionKOs', clearer => 'clear_reactionKOs', isa => 'ArrayRef[ModelSEED::MS::Reaction]');
+has additionalCpds => (is => 'rw', type => 'link(Biochemistry,compounds,additionalCpd_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_additionalCpds', clearer => 'clear_additionalCpds', isa => 'ArrayRef[ModelSEED::MS::Compound]');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBAPhenotypeSimultationResult.pm
+++ b/lib/ModelSEED/MS/DB/FBAPhenotypeSimultationResult.pm
@@ -27,7 +27,7 @@ has fbaPhenotypeSimulation_uuid => (is => 'rw', isa => 'ModelSEED::uuid', printO
 
 
 # LINKS:
-has fbaPhenotypeSimulation => (is => 'rw', isa => 'ModelSEED::MS::FBAPhenotypeSimulation', type => 'link(FBAFormulation,fbaPhenotypeSimulations,fbaPhenotypeSimulation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_fbaPhenotypeSimulation', clearer => 'clear_fbaPhenotypeSimulation', weak_ref => 1);
+has fbaPhenotypeSimulation => (is => 'rw', type => 'link(FBAFormulation,fbaPhenotypeSimulations,fbaPhenotypeSimulation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_fbaPhenotypeSimulation', clearer => 'clear_fbaPhenotypeSimulation', isa => 'ModelSEED::MS::FBAPhenotypeSimulation', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBAReactionBound.pm
+++ b/lib/ModelSEED/MS/DB/FBAReactionBound.pm
@@ -23,7 +23,7 @@ has lowerBound => (is => 'rw', isa => 'Num', printOrder => '-1', required => 1, 
 
 
 # LINKS:
-has modelReaction => (is => 'rw', isa => 'ModelSEED::MS::ModelReaction', type => 'link(Model,modelreactions,modelreaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelReaction', clearer => 'clear_modelReaction', weak_ref => 1);
+has modelReaction => (is => 'rw', type => 'link(Model,modelreactions,modelreaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelReaction', clearer => 'clear_modelReaction', isa => 'ModelSEED::MS::ModelReaction', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FBAReactionVariable.pm
+++ b/lib/ModelSEED/MS/DB/FBAReactionVariable.pm
@@ -27,7 +27,7 @@ has value => (is => 'rw', isa => 'Num', printOrder => '6', type => 'attribute', 
 
 
 # LINKS:
-has modelreaction => (is => 'rw', isa => 'ModelSEED::MS::ModelReaction', type => 'link(Model,modelreactions,modelreaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelreaction', clearer => 'clear_modelreaction', weak_ref => 1);
+has modelreaction => (is => 'rw', type => 'link(Model,modelreactions,modelreaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelreaction', clearer => 'clear_modelreaction', isa => 'ModelSEED::MS::ModelReaction', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/Feature.pm
+++ b/lib/ModelSEED/MS/DB/Feature.pm
@@ -39,7 +39,7 @@ has featureroles => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { re
 
 
 # LINKS:
-has genome => (is => 'rw', isa => 'ModelSEED::MS::Genome', type => 'link(Annotation,genomes,genome_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_genome', clearer => 'clear_genome', weak_ref => 1);
+has genome => (is => 'rw', type => 'link(Annotation,genomes,genome_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_genome', clearer => 'clear_genome', isa => 'ModelSEED::MS::Genome', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/FeatureRole.pm
+++ b/lib/ModelSEED/MS/DB/FeatureRole.pm
@@ -23,7 +23,7 @@ has delimiter => (is => 'rw', isa => 'Str', printOrder => '0', default => '', ty
 
 
 # LINKS:
-has role => (is => 'rw', isa => 'ModelSEED::MS::Role', type => 'link(Mapping,roles,role_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_role', clearer => 'clear_role', weak_ref => 1);
+has role => (is => 'rw', type => 'link(Mapping,roles,role_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_role', clearer => 'clear_role', isa => 'ModelSEED::MS::Role', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/GapfillingFormulation.pm
+++ b/lib/ModelSEED/MS/DB/GapfillingFormulation.pm
@@ -53,11 +53,11 @@ has gapfillingSolutions => (is => 'rw', isa => 'ArrayRef[HashRef]', default => s
 
 
 # LINKS:
-has model => (is => 'rw', isa => 'ModelSEED::MS::Model', type => 'link(ModelSEED::Store,Model,model_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_model', clearer => 'clear_model');
-has fbaFormulation => (is => 'rw', isa => 'ModelSEED::MS::FBAFormulation', type => 'link(ModelSEED::Store,FBAFormulation,fbaFormulation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_fbaFormulation', clearer => 'clear_fbaFormulation');
-has guaranteedReactions => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Reaction]', type => 'link(Biochemistry,reactions,guaranteedReaction_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_guaranteedReactions', clearer => 'clear_guaranteedReactions');
-has blacklistedReactions => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Reaction]', type => 'link(Biochemistry,reactions,blacklistedReaction_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_blacklistedReactions', clearer => 'clear_blacklistedReactions');
-has allowableCompartments => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Compartment]', type => 'link(Biochemistry,compartments,allowableCompartment_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_allowableCompartments', clearer => 'clear_allowableCompartments');
+has model => (is => 'rw', type => 'link(ModelSEED::Store,Model,model_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_model', clearer => 'clear_model', isa => 'ModelSEED::MS::Model');
+has fbaFormulation => (is => 'rw', type => 'link(ModelSEED::Store,FBAFormulation,fbaFormulation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_fbaFormulation', clearer => 'clear_fbaFormulation', isa => 'ModelSEED::MS::FBAFormulation');
+has guaranteedReactions => (is => 'rw', type => 'link(Biochemistry,reactions,guaranteedReaction_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_guaranteedReactions', clearer => 'clear_guaranteedReactions', isa => 'ArrayRef[ModelSEED::MS::Reaction]');
+has blacklistedReactions => (is => 'rw', type => 'link(Biochemistry,reactions,blacklistedReaction_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_blacklistedReactions', clearer => 'clear_blacklistedReactions', isa => 'ArrayRef[ModelSEED::MS::Reaction]');
+has allowableCompartments => (is => 'rw', type => 'link(Biochemistry,compartments,allowableCompartment_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_allowableCompartments', clearer => 'clear_allowableCompartments', isa => 'ArrayRef[ModelSEED::MS::Compartment]');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/GapfillingGeneCandidate.pm
+++ b/lib/ModelSEED/MS/DB/GapfillingGeneCandidate.pm
@@ -25,10 +25,10 @@ has role_uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '-1', type
 
 
 # LINKS:
-has feature => (is => 'rw', isa => 'ModelSEED::MS::Feature', type => 'link(Annotation,features,feature_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_feature', clearer => 'clear_feature', weak_ref => 1);
-has ortholog => (is => 'rw', isa => 'ModelSEED::MS::Feature', type => 'link(Annotation,features,ortholog_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_ortholog', clearer => 'clear_ortholog', weak_ref => 1);
-has orthologGenome => (is => 'rw', isa => 'ModelSEED::MS::Genome', type => 'link(Annotation,genomes,orthogenome_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_orthologGenome', clearer => 'clear_orthologGenome', weak_ref => 1);
-has role => (is => 'rw', isa => 'ModelSEED::MS::Role', type => 'link(Mapping,roles,role_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_role', clearer => 'clear_role', weak_ref => 1);
+has feature => (is => 'rw', type => 'link(Annotation,features,feature_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_feature', clearer => 'clear_feature', isa => 'ModelSEED::MS::Feature', weak_ref => 1);
+has ortholog => (is => 'rw', type => 'link(Annotation,features,ortholog_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_ortholog', clearer => 'clear_ortholog', isa => 'ModelSEED::MS::Feature', weak_ref => 1);
+has orthologGenome => (is => 'rw', type => 'link(Annotation,genomes,orthogenome_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_orthologGenome', clearer => 'clear_orthologGenome', isa => 'ModelSEED::MS::Genome', weak_ref => 1);
+has role => (is => 'rw', type => 'link(Mapping,roles,role_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_role', clearer => 'clear_role', isa => 'ModelSEED::MS::Role', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/GapfillingSolution.pm
+++ b/lib/ModelSEED/MS/DB/GapfillingSolution.pm
@@ -34,9 +34,9 @@ has gapfillingSolutionReactions => (is => 'rw', isa => 'ArrayRef[HashRef]', defa
 
 
 # LINKS:
-has biomassRemovals => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::ModelCompound]', type => 'link(Model,modelcompounds,biomassRemoval_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_biomassRemovals', clearer => 'clear_biomassRemovals');
-has mediaSupplements => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::ModelCompound]', type => 'link(Model,modelcompounds,mediaSupplement_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_mediaSupplements', clearer => 'clear_mediaSupplements');
-has koRestores => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::ModelReaction]', type => 'link(Model,modelreactions,koRestore_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_koRestores', clearer => 'clear_koRestores');
+has biomassRemovals => (is => 'rw', type => 'link(Model,modelcompounds,biomassRemoval_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_biomassRemovals', clearer => 'clear_biomassRemovals', isa => 'ArrayRef[ModelSEED::MS::ModelCompound]');
+has mediaSupplements => (is => 'rw', type => 'link(Model,modelcompounds,mediaSupplement_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_mediaSupplements', clearer => 'clear_mediaSupplements', isa => 'ArrayRef[ModelSEED::MS::ModelCompound]');
+has koRestores => (is => 'rw', type => 'link(Model,modelreactions,koRestore_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_koRestores', clearer => 'clear_koRestores', isa => 'ArrayRef[ModelSEED::MS::ModelReaction]');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/GapfillingSolutionReaction.pm
+++ b/lib/ModelSEED/MS/DB/GapfillingSolutionReaction.pm
@@ -23,8 +23,8 @@ has candidateFeature_uuids => (is => 'rw', isa => 'ArrayRef', printOrder => '-1'
 
 
 # LINKS:
-has reaction => (is => 'rw', isa => 'ModelSEED::MS::Reaction', type => 'link(Biochemistry,reactions,reaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_reaction', clearer => 'clear_reaction', weak_ref => 1);
-has candidateFeatures => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Feature]', type => 'link(Annotation,features,candidateFeature_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_candidateFeatures', clearer => 'clear_candidateFeatures');
+has reaction => (is => 'rw', type => 'link(Biochemistry,reactions,reaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_reaction', clearer => 'clear_reaction', isa => 'ModelSEED::MS::Reaction', weak_ref => 1);
+has candidateFeatures => (is => 'rw', type => 'link(Annotation,features,candidateFeature_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_candidateFeatures', clearer => 'clear_candidateFeatures', isa => 'ArrayRef[ModelSEED::MS::Feature]');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/GapgenFormulation.pm
+++ b/lib/ModelSEED/MS/DB/GapgenFormulation.pm
@@ -37,9 +37,9 @@ has gapgenSolutions => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub {
 
 
 # LINKS:
-has model => (is => 'rw', isa => 'ModelSEED::MS::Model', type => 'link(ModelSEED::Store,Model,model_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_model', clearer => 'clear_model');
-has fbaFormulation => (is => 'rw', isa => 'ModelSEED::MS::FBAFormulation', type => 'link(ModelSEED::Store,FBAFormulation,fbaFormulation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_fbaFormulation', clearer => 'clear_fbaFormulation');
-has referenceMedia => (is => 'rw', isa => 'ModelSEED::MS::Media', type => 'link(Biochemistry,media,referenceMedia_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_referenceMedia', clearer => 'clear_referenceMedia', weak_ref => 1);
+has model => (is => 'rw', type => 'link(ModelSEED::Store,Model,model_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_model', clearer => 'clear_model', isa => 'ModelSEED::MS::Model');
+has fbaFormulation => (is => 'rw', type => 'link(ModelSEED::Store,FBAFormulation,fbaFormulation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_fbaFormulation', clearer => 'clear_fbaFormulation', isa => 'ModelSEED::MS::FBAFormulation');
+has referenceMedia => (is => 'rw', type => 'link(Biochemistry,media,referenceMedia_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_referenceMedia', clearer => 'clear_referenceMedia', isa => 'ModelSEED::MS::Media', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/GapgenSolution.pm
+++ b/lib/ModelSEED/MS/DB/GapgenSolution.pm
@@ -34,9 +34,9 @@ has gapgenSolutionReactions => (is => 'rw', isa => 'ArrayRef[HashRef]', default 
 
 
 # LINKS:
-has biomassSupplements => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::ModelCompound]', type => 'link(Model,modelcompounds,biomassSupplement_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_biomassSupplements', clearer => 'clear_biomassSupplements');
-has mediaRemovals => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::ModelCompound]', type => 'link(Model,modelcompounds,mediaRemoval_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_mediaRemovals', clearer => 'clear_mediaRemovals');
-has additionalKOs => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::ModelReaction]', type => 'link(Model,modelreactions,additionalKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_additionalKOs', clearer => 'clear_additionalKOs');
+has biomassSupplements => (is => 'rw', type => 'link(Model,modelcompounds,biomassSupplement_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_biomassSupplements', clearer => 'clear_biomassSupplements', isa => 'ArrayRef[ModelSEED::MS::ModelCompound]');
+has mediaRemovals => (is => 'rw', type => 'link(Model,modelcompounds,mediaRemoval_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_mediaRemovals', clearer => 'clear_mediaRemovals', isa => 'ArrayRef[ModelSEED::MS::ModelCompound]');
+has additionalKOs => (is => 'rw', type => 'link(Model,modelreactions,additionalKO_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_additionalKOs', clearer => 'clear_additionalKOs', isa => 'ArrayRef[ModelSEED::MS::ModelReaction]');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/GapgenSolutionReaction.pm
+++ b/lib/ModelSEED/MS/DB/GapgenSolutionReaction.pm
@@ -21,7 +21,7 @@ has direction => (is => 'rw', isa => 'Str', printOrder => '0', default => '1', t
 
 
 # LINKS:
-has modelreaction => (is => 'rw', isa => 'ModelSEED::MS::ModelReaction', type => 'link(Model,modelreactions,modelreaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelreaction', clearer => 'clear_modelreaction', weak_ref => 1);
+has modelreaction => (is => 'rw', type => 'link(Model,modelreactions,modelreaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelreaction', clearer => 'clear_modelreaction', isa => 'ModelSEED::MS::ModelReaction', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/Mapping.pm
+++ b/lib/ModelSEED/MS/DB/Mapping.pm
@@ -45,7 +45,7 @@ has aliasSets => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { retur
 
 
 # LINKS:
-has biochemistry => (is => 'rw', isa => 'ModelSEED::MS::Biochemistry', type => 'link(ModelSEED::Store,Biochemistry,biochemistry_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_biochemistry', clearer => 'clear_biochemistry');
+has biochemistry => (is => 'rw', type => 'link(ModelSEED::Store,Biochemistry,biochemistry_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_biochemistry', clearer => 'clear_biochemistry', isa => 'ModelSEED::MS::Biochemistry');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/MediaCompound.pm
+++ b/lib/ModelSEED/MS/DB/MediaCompound.pm
@@ -23,7 +23,7 @@ has minFlux => (is => 'rw', isa => 'Num', printOrder => '0', default => '-100', 
 
 
 # LINKS:
-has compound => (is => 'rw', isa => 'ModelSEED::MS::Compound', type => 'link(Biochemistry,compounds,compound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compound', clearer => 'clear_compound', weak_ref => 1);
+has compound => (is => 'rw', type => 'link(Biochemistry,compounds,compound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compound', clearer => 'clear_compound', isa => 'ModelSEED::MS::Compound', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/Model.pm
+++ b/lib/ModelSEED/MS/DB/Model.pm
@@ -55,14 +55,14 @@ has modelreactions => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { 
 
 
 # LINKS:
-has fbaFormulations => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::FBAFormulation]', type => 'link(ModelSEED::Store,FBAFormulation,fbaFormulation_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_fbaFormulations', clearer => 'clear_fbaFormulations');
-has unintegratedGapfillings => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::GapfillingFormulation]', type => 'link(ModelSEED::Store,GapfillingFormulation,unintegratedGapfilling_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_unintegratedGapfillings', clearer => 'clear_unintegratedGapfillings');
-has integratedGapfillings => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::GapfillingFormulation]', type => 'link(ModelSEED::Store,GapfillingFormulation,integratedGapfilling_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_integratedGapfillings', clearer => 'clear_integratedGapfillings');
-has unintegratedGapgens => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::GapgenFormulation]', type => 'link(ModelSEED::Store,GapgenFormulation,unintegratedGapgen_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_unintegratedGapgens', clearer => 'clear_unintegratedGapgens');
-has integratedGapgens => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::GapgenFormulation]', type => 'link(ModelSEED::Store,GapgenFormulation,integratedGapgen_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_integratedGapgens', clearer => 'clear_integratedGapgens');
-has biochemistry => (is => 'rw', isa => 'ModelSEED::MS::Biochemistry', type => 'link(ModelSEED::Store,Biochemistry,biochemistry_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_biochemistry', clearer => 'clear_biochemistry');
-has mapping => (is => 'rw', isa => 'ModelSEED::MS::Mapping', type => 'link(ModelSEED::Store,Mapping,mapping_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_mapping', clearer => 'clear_mapping');
-has annotation => (is => 'rw', isa => 'ModelSEED::MS::Annotation', type => 'link(ModelSEED::Store,Annotation,annotation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_annotation', clearer => 'clear_annotation');
+has fbaFormulations => (is => 'rw', type => 'link(ModelSEED::Store,FBAFormulation,fbaFormulation_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_fbaFormulations', clearer => 'clear_fbaFormulations', isa => 'ArrayRef[ModelSEED::MS::FBAFormulation]');
+has unintegratedGapfillings => (is => 'rw', type => 'link(ModelSEED::Store,GapfillingFormulation,unintegratedGapfilling_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_unintegratedGapfillings', clearer => 'clear_unintegratedGapfillings', isa => 'ArrayRef[ModelSEED::MS::GapfillingFormulation]');
+has integratedGapfillings => (is => 'rw', type => 'link(ModelSEED::Store,GapfillingFormulation,integratedGapfilling_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_integratedGapfillings', clearer => 'clear_integratedGapfillings', isa => 'ArrayRef[ModelSEED::MS::GapfillingFormulation]');
+has unintegratedGapgens => (is => 'rw', type => 'link(ModelSEED::Store,GapgenFormulation,unintegratedGapgen_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_unintegratedGapgens', clearer => 'clear_unintegratedGapgens', isa => 'ArrayRef[ModelSEED::MS::GapgenFormulation]');
+has integratedGapgens => (is => 'rw', type => 'link(ModelSEED::Store,GapgenFormulation,integratedGapgen_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_integratedGapgens', clearer => 'clear_integratedGapgens', isa => 'ArrayRef[ModelSEED::MS::GapgenFormulation]');
+has biochemistry => (is => 'rw', type => 'link(ModelSEED::Store,Biochemistry,biochemistry_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_biochemistry', clearer => 'clear_biochemistry', isa => 'ModelSEED::MS::Biochemistry');
+has mapping => (is => 'rw', type => 'link(ModelSEED::Store,Mapping,mapping_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_mapping', clearer => 'clear_mapping', isa => 'ModelSEED::MS::Mapping');
+has annotation => (is => 'rw', type => 'link(ModelSEED::Store,Annotation,annotation_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_annotation', clearer => 'clear_annotation', isa => 'ModelSEED::MS::Annotation');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/ModelCompartment.pm
+++ b/lib/ModelSEED/MS/DB/ModelCompartment.pm
@@ -30,7 +30,7 @@ has ancestor_uuid => (is => 'rw', isa => 'uuid', type => 'ancestor', metaclass =
 
 
 # LINKS:
-has compartment => (is => 'rw', isa => 'ModelSEED::MS::Compartment', type => 'link(Biochemistry,compartments,compartment_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compartment', clearer => 'clear_compartment', weak_ref => 1);
+has compartment => (is => 'rw', type => 'link(Biochemistry,compartments,compartment_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compartment', clearer => 'clear_compartment', isa => 'ModelSEED::MS::Compartment', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/ModelCompound.pm
+++ b/lib/ModelSEED/MS/DB/ModelCompound.pm
@@ -29,8 +29,8 @@ has ancestor_uuid => (is => 'rw', isa => 'uuid', type => 'ancestor', metaclass =
 
 
 # LINKS:
-has compound => (is => 'rw', isa => 'ModelSEED::MS::Compound', type => 'link(Biochemistry,compounds,compound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compound', clearer => 'clear_compound', weak_ref => 1);
-has modelcompartment => (is => 'rw', isa => 'ModelSEED::MS::ModelCompartment', type => 'link(Model,modelcompartments,modelcompartment_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelcompartment', clearer => 'clear_modelcompartment', weak_ref => 1);
+has compound => (is => 'rw', type => 'link(Biochemistry,compounds,compound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compound', clearer => 'clear_compound', isa => 'ModelSEED::MS::Compound', weak_ref => 1);
+has modelcompartment => (is => 'rw', type => 'link(Model,modelcompartments,modelcompartment_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelcompartment', clearer => 'clear_modelcompartment', isa => 'ModelSEED::MS::ModelCompartment', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/ModelReaction.pm
+++ b/lib/ModelSEED/MS/DB/ModelReaction.pm
@@ -36,8 +36,8 @@ has modelReactionReagents => (is => 'rw', isa => 'ArrayRef[HashRef]', default =>
 
 
 # LINKS:
-has reaction => (is => 'rw', isa => 'ModelSEED::MS::Reaction', type => 'link(Biochemistry,reactions,reaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_reaction', clearer => 'clear_reaction', weak_ref => 1);
-has modelcompartment => (is => 'rw', isa => 'ModelSEED::MS::ModelCompartment', type => 'link(Model,modelcompartments,modelcompartment_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelcompartment', clearer => 'clear_modelcompartment', weak_ref => 1);
+has reaction => (is => 'rw', type => 'link(Biochemistry,reactions,reaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_reaction', clearer => 'clear_reaction', isa => 'ModelSEED::MS::Reaction', weak_ref => 1);
+has modelcompartment => (is => 'rw', type => 'link(Model,modelcompartments,modelcompartment_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelcompartment', clearer => 'clear_modelcompartment', isa => 'ModelSEED::MS::ModelCompartment', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/ModelReactionProtein.pm
+++ b/lib/ModelSEED/MS/DB/ModelReactionProtein.pm
@@ -26,7 +26,7 @@ has modelReactionProteinSubunits => (is => 'rw', isa => 'ArrayRef[HashRef]', def
 
 
 # LINKS:
-has complex => (is => 'rw', isa => 'ModelSEED::MS::Complex', type => 'link(Mapping,complexes,complex_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_complex', clearer => 'clear_complex', weak_ref => 1);
+has complex => (is => 'rw', type => 'link(Mapping,complexes,complex_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_complex', clearer => 'clear_complex', isa => 'ModelSEED::MS::Complex', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/ModelReactionProteinSubunit.pm
+++ b/lib/ModelSEED/MS/DB/ModelReactionProteinSubunit.pm
@@ -28,7 +28,7 @@ has modelReactionProteinSubunitGenes => (is => 'rw', isa => 'ArrayRef[HashRef]',
 
 
 # LINKS:
-has role => (is => 'rw', isa => 'ModelSEED::MS::Role', type => 'link(Mapping,roles,role_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_role', clearer => 'clear_role', weak_ref => 1);
+has role => (is => 'rw', type => 'link(Mapping,roles,role_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_role', clearer => 'clear_role', isa => 'ModelSEED::MS::Role', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/ModelReactionProteinSubunitGene.pm
+++ b/lib/ModelSEED/MS/DB/ModelReactionProteinSubunitGene.pm
@@ -20,7 +20,7 @@ has feature_uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '0', re
 
 
 # LINKS:
-has feature => (is => 'rw', isa => 'ModelSEED::MS::Feature', type => 'link(Annotation,features,feature_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_feature', clearer => 'clear_feature', weak_ref => 1);
+has feature => (is => 'rw', type => 'link(Annotation,features,feature_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_feature', clearer => 'clear_feature', isa => 'ModelSEED::MS::Feature', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/ModelReactionReagent.pm
+++ b/lib/ModelSEED/MS/DB/ModelReactionReagent.pm
@@ -21,7 +21,7 @@ has coefficient => (is => 'rw', isa => 'Num', printOrder => '0', required => 1, 
 
 
 # LINKS:
-has modelcompound => (is => 'rw', isa => 'ModelSEED::MS::ModelCompound', type => 'link(Model,modelcompounds,modelcompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelcompound', clearer => 'clear_modelcompound', weak_ref => 1);
+has modelcompound => (is => 'rw', type => 'link(Model,modelcompounds,modelcompound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_modelcompound', clearer => 'clear_modelcompound', isa => 'ModelSEED::MS::ModelCompound', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/Reaction.pm
+++ b/lib/ModelSEED/MS/DB/Reaction.pm
@@ -41,7 +41,7 @@ has reagents => (is => 'rw', isa => 'ArrayRef[HashRef]', default => sub { return
 
 
 # LINKS:
-has abstractReaction => (is => 'rw', isa => 'ModelSEED::MS::Reaction', type => 'link(Biochemistry,reactions,abstractReaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_abstractReaction', clearer => 'clear_abstractReaction', weak_ref => 1);
+has abstractReaction => (is => 'rw', type => 'link(Biochemistry,reactions,abstractReaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_abstractReaction', clearer => 'clear_abstractReaction', isa => 'Maybe[ModelSEED::MS::Reaction]', weak_ref => 1);
 has id => (is => 'rw', lazy => 1, builder => '_build_id', isa => 'Str', type => 'id', metaclass => 'Typed');
 
 
@@ -183,7 +183,8 @@ my $links = [
             'clearer' => 'clear_abstractReaction',
             'name' => 'abstractReaction',
             'class' => 'reactions',
-            'method' => 'reactions'
+            'method' => 'reactions',
+            'can_be_undef' => 1
           }
         ];
 

--- a/lib/ModelSEED/MS/DB/ReactionSet.pm
+++ b/lib/ModelSEED/MS/DB/ReactionSet.pm
@@ -30,7 +30,7 @@ has ancestor_uuid => (is => 'rw', isa => 'uuid', type => 'ancestor', metaclass =
 
 
 # LINKS:
-has reactions => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Reaction]', type => 'link(Biochemistry,reactions,reaction_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_reactions', clearer => 'clear_reactions');
+has reactions => (is => 'rw', type => 'link(Biochemistry,reactions,reaction_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_reactions', clearer => 'clear_reactions', isa => 'ArrayRef[ModelSEED::MS::Reaction]');
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/ReactionSetMultiplier.pm
+++ b/lib/ModelSEED/MS/DB/ReactionSetMultiplier.pm
@@ -24,7 +24,7 @@ has multiplier => (is => 'rw', isa => 'Num', printOrder => '-1', type => 'attrib
 
 
 # LINKS:
-has reactionset => (is => 'rw', isa => 'ModelSEED::MS::ReactionSet', type => 'link(Biochemistry,reactionSets,reactionset_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_reactionset', clearer => 'clear_reactionset', weak_ref => 1);
+has reactionset => (is => 'rw', type => 'link(Biochemistry,reactionSets,reactionset_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_reactionset', clearer => 'clear_reactionset', isa => 'ModelSEED::MS::ReactionSet', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/Reagent.pm
+++ b/lib/ModelSEED/MS/DB/Reagent.pm
@@ -23,8 +23,8 @@ has isCofactor => (is => 'rw', isa => 'Bool', printOrder => '0', default => '0',
 
 
 # LINKS:
-has compound => (is => 'rw', isa => 'ModelSEED::MS::Compound', type => 'link(Biochemistry,compounds,compound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compound', clearer => 'clear_compound', weak_ref => 1);
-has compartment => (is => 'rw', isa => 'ModelSEED::MS::Compartment', type => 'link(Biochemistry,compartments,compartment_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compartment', clearer => 'clear_compartment', weak_ref => 1);
+has compound => (is => 'rw', type => 'link(Biochemistry,compounds,compound_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compound', clearer => 'clear_compound', isa => 'ModelSEED::MS::Compound', weak_ref => 1);
+has compartment => (is => 'rw', type => 'link(Biochemistry,compartments,compartment_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_compartment', clearer => 'clear_compartment', isa => 'ModelSEED::MS::Compartment', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/DB/RoleSet.pm
+++ b/lib/ModelSEED/MS/DB/RoleSet.pm
@@ -30,7 +30,7 @@ has ancestor_uuid => (is => 'rw', isa => 'uuid', type => 'ancestor', metaclass =
 
 
 # LINKS:
-has roles => (is => 'rw', isa => 'ArrayRef[ModelSEED::MS::Role]', type => 'link(Mapping,roles,role_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_roles', clearer => 'clear_roles');
+has roles => (is => 'rw', type => 'link(Mapping,roles,role_uuids)', metaclass => 'Typed', lazy => 1, builder => '_build_roles', clearer => 'clear_roles', isa => 'ArrayRef[ModelSEED::MS::Role]');
 has id => (is => 'rw', lazy => 1, builder => '_build_id', isa => 'Str', type => 'id', metaclass => 'Typed');
 
 

--- a/lib/ModelSEED/MS/DB/UniversalReaction.pm
+++ b/lib/ModelSEED/MS/DB/UniversalReaction.pm
@@ -21,7 +21,7 @@ has reaction_uuid => (is => 'rw', isa => 'ModelSEED::uuid', printOrder => '0', r
 
 
 # LINKS:
-has reaction => (is => 'rw', isa => 'ModelSEED::MS::Reaction', type => 'link(Biochemistry,reactions,reaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_reaction', clearer => 'clear_reaction', weak_ref => 1);
+has reaction => (is => 'rw', type => 'link(Biochemistry,reactions,reaction_uuid)', metaclass => 'Typed', lazy => 1, builder => '_build_reaction', clearer => 'clear_reaction', isa => 'ModelSEED::MS::Reaction', weak_ref => 1);
 
 
 # BUILDERS:

--- a/lib/ModelSEED/MS/IndexedObject.pm
+++ b/lib/ModelSEED/MS/IndexedObject.pm
@@ -59,7 +59,8 @@ This defaults to "aliasName" if not supplied.
 
 =head3 getObjectByAlias 
 
-	$aliased = $obj->getObjectByAlias($attribute,$alias,$aliasName);
+	$aliased = $obj->getObjectByAlias($attribute,$alias,$aliasSet);
+    $aliased = $obj->getObjectByAlias("compounds", "cpd01234", "ModelSEED");
 
 Return the first object that is matched by the provided alias.
 C<$attribute> is the attribute name for which the alias would apply,

--- a/lib/ModelSEED/MS/Metadata/Definitions.pm
+++ b/lib/ModelSEED/MS/Metadata/Definitions.pm
@@ -2599,7 +2599,8 @@ $objectDefinitions->{Compound} = {
 			name      => "abstractCompound",
 			attribute => "abstractCompound_uuid",
 			parent    => "Biochemistry",
-			method    => "compounds"
+			method    => "compounds",
+            can_be_undef => 1,
 		},
 		{
 			name      => "comprisedOfCompounds",
@@ -2736,7 +2737,8 @@ $objectDefinitions->{Reaction} = {
 			name      => "abstractReaction",
 			attribute => "abstractReaction_uuid",
 			parent    => "Biochemistry",
-			method    => "reactions"
+			method    => "reactions",
+            can_be_undef => 1,
 		}
 	],
 	reference_id_types => [qw(uuid)],

--- a/scripts/ObjectBuilder.pl
+++ b/scripts/ObjectBuilder.pl
@@ -164,6 +164,8 @@ foreach my $name (keys(%{$objects})) {
             my $parent = $subobject->{parent};
             my $method = $subobject->{method};
             my $attr = $subobject->{attribute};
+            my $can_be_undef = $subobject->{can_be_undef};
+               $can_be_undef = 0 unless defined $can_be_undef;
             $subobject->{clearer} = "clear_".$soname;
             if (defined($functionToType->{$method})) {
             	$subobject->{class} = $functionToType->{$method};
@@ -190,13 +192,17 @@ foreach my $name (keys(%{$objects})) {
             }
             my $props = [
                 "is => 'rw'",
-                "isa => '".$type."'",
                 "type => 'link($parent,$method,$attr)'",
                 "metaclass => 'Typed'",
                 "lazy => 1",
                 "builder => '_build_$soname'",
             	"clearer => 'clear_$soname'",
             ];
+            if($can_be_undef) {
+                push(@$props, "isa => 'Maybe[$type]'");
+            } else {
+                push(@$props, "isa => '$type'");
+            }
             push(@$props, "weak_ref => 1") if($weak);
             push(@$output, "has $soname => (" . join(", ", @$props) . ");");
         }


### PR DESCRIPTION
- Introduced a can_be_undef on link objects. These
  objects will not fail when getLinkedObject is called.
