### PR TITLE
Fixes for KBase clients, fix ms list command

### DIFF
--- a/lib/ModelSEED/App/mseed/Command/list.pm
+++ b/lib/ModelSEED/App/mseed/Command/list.pm
@@ -44,7 +44,7 @@ sub execute {
             if ($opts->{mine}) {
                 $aliases = $store->get_aliases({ type => $ref->base, owner => $auth->username });
             } else {
-                $aliases = $store->get_aliases({ type => $ref->base, owner => $auth->username });
+                $aliases = $store->get_aliases({ type => $ref->base });
             }
             # Construct references from alias data
             # TODO: Why isn't this part of Store / Database ?

--- a/lib/ModelSEED/Database/Composite.pm
+++ b/lib/ModelSEED/Database/Composite.pm
@@ -130,6 +130,7 @@ use Try::Tiny;
 use Class::Autouse qw(
     ModelSEED::Configuration
     ModelSEED::Database::FileDB
+    ModelSEED::Database::KBaseRPC
     ModelSEED::Database::MongoDBSimple
     JSON::XS
 );
@@ -166,7 +167,7 @@ around BUILDARGS => sub {
         } catch {
             ModelSEED::Exception::DatabaseConfigError->throw(
                 dbName => $config{name},
-                configText => JSON::XS->new->pretty(1)->encode(\%config),
+                configText => "$_\n" . JSON::XS->new->pretty(1)->encode(\%config),
             );
         };
     }


### PR DESCRIPTION
- Fix ms list command, now lists all owned and visible aliases
  by default. Still has the --mine or -m flag for only listing your
  objects.
- Fix Composite class to work with KBaseRPC
- Fix KBaseRPC to strip the Auth object, cast ModelSEED::Reference
  objects back into strings for wire serialization.

Ready to merge. Probably won't pass tests until the  <del>jenkins</del> travis branch is merged.
