### PR TITLE
Compound reaction loading

### DIFF
--- a/lib/ModelSEED/App/bio/Command/addcpdtable.pm
+++ b/lib/ModelSEED/App/bio/Command/addcpdtable.pm
@@ -13,6 +13,8 @@ sub opt_spec {
     return (
         ["saveas|a:s", "New alias for altered biochemistry"],
         ["namespace|n:s", "Name space for aliases added"],
+        ["mergeto|m:s", "Name space of identifiers used for merging compounds"],
+        ["verbose|v", "Print verbose status information"]
     );
 }
 
@@ -21,38 +23,62 @@ sub execute {
     my $auth  = ModelSEED::Auth::Factory->new->from_config;
     my $store = ModelSEED::Store->new(auth => $auth);
     my $helper = ModelSEED::App::Helpers->new();
-    my ($biochemistry,my $ref) = $helper->get_object("biochemistry", $args, $store);
-    $self->usage_error("Must specify an biochemistry to use") unless(defined($biochemistry));
+    my ($biochemistry, $ref) = $helper->get_object("biochemistry", $args, $store);
+    $self->usage_error("Must specify a biochemistry to use") unless(defined($biochemistry));
     $self->usage_error("Must specify a valid filename for compound table") unless(defined($args->[1]) && -e $args->[1]);
+
+    #verbosity
+    if ($opts->{verbose}) {
+    	ModelSEED::utilities::SETVERBOSE(1);
+    	delete $opts->{verbose};
+    }
+
+    #load table
     my $tbl = ModelSEED::utilities::LOADTABLE($args->[1],"\\t");
+
+    #set namespace
     if (!defined($opts->{namespace})) {
-    	$opts->{namespace} = $biochemistry->defaultNameSpace();
-    } 
+	$opts->{namespace} = $args->[0];
+	print STDERR "Warning: no namespace passed.  Using biochemistry name by default: ".$opts->{namespace}."\n";
+    }
+
+    #creating namespaces if they don't exist
+    if(!$biochemistry->queryObject("aliasSets",{name => $opts->{namespace},attribute=>"compounds"})){
+	$biochemistry->add("aliasSets",{
+	    name => $opts->{namespace},
+	    source => $opts->{namespace},
+	    attribute => "compounds",
+	    class => "Compound"});
+    }
+    if(defined($opts->{mergeto}) && !$biochemistry->queryObject("aliasSets",{name => $opts->{mergeto},attribute=>"compounds"})){
+	$biochemistry->add("aliasSets",{
+	    name => $opts->{mergeto},
+	    source => $opts->{mergeto},
+	    attribute => "compounds",
+	    class => "Compound"});
+    }
+
     for (my $i=0; $i < @{$tbl->{data}}; $i++) {
     	my $cpdData = {aliasType => $opts->{namespace}};
     	for (my $j=0; $j < @{$tbl->{headings}}; $j++) {
-    		my $heading = $tbl->{headings}->[$j];
-    		if ($heading eq "names") {
-    			$cpdData->{$heading} = [split(/\|/,$tbl->{data}->[$i]->[$j])];
+    		my $heading = lc($tbl->{headings}->[$j]);
+    		if ($heading =~ /names?/) {
+		    $heading="names" if $heading eq "name";
+		    $cpdData->{$heading} = [split(/\|/,$tbl->{data}->[$i]->[$j])];
     		} else {
-    			$cpdData->{$heading} = [$tbl->{data}->[$i]->[$j]];
+		    $cpdData->{$heading} = [$tbl->{data}->[$i]->[$j]];
     		}
     	}
-    	my $cpd = $biochemistry->addCompoundFromHash($cpdData);
-    	if (defined($cpd)) {
-    		push(@{$tbl->{data}->[$i]},$cpd->uuid());
-    	}
+    	my $cpd = $biochemistry->addCompoundFromHash($cpdData,$opts->{mergeto});
     }
-    push(@{$tbl->{headings}},"uuid");
     if (defined($opts->{saveas})) {
     	$ref = $helper->process_ref_string($opts->{saveas}, "biochemistry", $auth->username);
     	print STDERR "Saving biochemistry with new compounds as ".$ref."...\n" if($opts->{verbose});
-		$store->save_object($ref,$biochemistry);
+	$store->save_object($ref,$biochemistry);
     } else {
     	print STDERR "Saving over original biochemistry with new compounds...\n" if($opts->{verbose});
     	$store->save_object($ref,$biochemistry);
     }
-    ModelSEED::utilities::PRINTTABLE("STDOUT",$tbl);
 }
 
 1;

--- a/lib/ModelSEED/MS/Biochemistry.pm
+++ b/lib/ModelSEED/MS/Biochemistry.pm
@@ -371,15 +371,10 @@ Description:
 
 sub addCompoundFromHash {
 	my ($self,$args,$mergeto) = @_;
-
-	#remove names that are too long
-	$arg->{names} = [ grep { length($_) < 255 } @{$arg->{names}} ];
-
-	#in case all the names were too long
-	if(!$args->{names}->[0]){
-	    push(@{$args->{names}},$args->{id}->[0]);
-	}
-	
+	# Remove names that are too long
+	$args->{names} = [ grep { length($_) < 255 } @{$args->{names}} ];
+	# In case all the names were too long, use the id as the name
+        push(@{$args->names}, $args->{id}->[0]) unless(@{$args->{names}});
 	$args = ModelSEED::utilities::ARGS($args,["names","id"],{
 		aliasType => $self->defaultNameSpace(),
 		abbreviation => [$args->{names}->[0]],
@@ -389,8 +384,7 @@ sub addCompoundFromHash {
 		deltag => [10000000],
 		deltagerr => [10000000]
 	});
-
-	#Checking for id uniqueness within scope of own aliasType
+	# Checking for id uniqueness within scope of own aliasType
 	my $cpd = $self->getObjectByAlias("compounds",$args->{id}->[0],$args->{aliasType});
 	if (defined($cpd)) {
 	    ModelSEED::utilities::VERBOSEMSG("Compound found with matching id ".$args->{id}->[0]." for namespace ".$args->{aliasType});
@@ -403,8 +397,7 @@ sub addCompoundFromHash {
 	    }
 	    return $cpd;
 	}
-
-	#Checking for id uniqueness within scope of another aliasType, if passed
+	# Checking for id uniqueness within scope of another aliasType, if passed
 	if($mergeto){
 	    $cpd = $self->getObjectByAlias("compounds",$args->{id}->[0],$mergeto);
 	    if (defined($cpd)) {
@@ -419,10 +412,9 @@ sub addCompoundFromHash {
 		return $cpd;
 	    }
 	}
-
-	#Disabled, attempting to check names ahead of chemical structure is not recommended
-	#For metabolic models, every compound is assumed to be unique anyway
-	#Checking for name uniqueness
+	# Disabled, attempting to check names ahead of chemical structure is not recommended
+	# For metabolic models, every compound is assumed to be unique anyway
+	# Checking for name uniqueness
 	#foreach my $name (@{$args->{names}}) {
 	#	my $searchname = ModelSEED::MS::Compound::nameToSearchname($name);
 	#	$cpd = $self->queryObject("compounds",{searchnames => $name});
@@ -438,7 +430,7 @@ sub addCompoundFromHash {
 	#	}
 	#}
 
-	#Actually creating compound
+	# Actually creating compound
 	$cpd = $self->add("compounds",{
 		name => $args->{names}->[0],
 		abbreviation => $args->{abbreviation}->[0],
@@ -448,7 +440,7 @@ sub addCompoundFromHash {
 		deltaG => $args->{deltag}->[0],
 		deltaGErr => $args->{deltagerr}->[0]
 	});
-	#Adding id as alias
+	# Adding id as alias
 	$self->addAlias({
 		attribute => "compounds",
 		aliasName => $args->{aliasType},
@@ -463,7 +455,7 @@ sub addCompoundFromHash {
 		uuid => $cpd->uuid()
 			    });
 	}
-	#Adding alternative names as aliases
+	# Adding alternative names as aliases
 	foreach my $name (@{$args->{names}}) {
 		$self->addAlias({
 			attribute => "compounds",
@@ -473,8 +465,7 @@ sub addCompoundFromHash {
 		});
 	}
 	return $cpd;
-
-	#TODO: allow user option to merge based on InChI strings (if included) and/or names
+	# TODO: allow user option to merge based on InChI strings (if included) and/or names
 }
 
 =head3 addReactionFromHash


### PR DESCRIPTION
Debugged and expanded the addcpdtable and addrxntable commands.  Of note is the ability to now state which current namespace you would like to match the identifiers to, i.e.:

```
ms bio addcpdtable BioCyc  <file1> -n MetaCyc -m BioCyc
ms bio addcpdtable BioCyc  <file2> -n PlantCyc -m BioCyc
```

Printing out the number of compounds in each namespace gives you:

```
MetaCyc 12358
PlantCyc 3776
BioCyc 12506
```

Showing how roughly 3500 PlantCyc identifiers match MetaCyc identifiers.
