### PR TITLE
Inlining of verbose output and otherwise mandatory informational messages

### DIFF
--- a/lib/ModelSEED/utilities.pm
+++ b/lib/ModelSEED/utilities.pm
@@ -53,11 +53,11 @@ messages: C<verbose> and C<set_verbose>.
 
 =head3 verbose
 
-    $rtv = verbose("string one", "string two");
+    $fh = verbose("string one", "string two");
 
 Call with a list of strings to print a message if the verbose flag has been
-set. If the list of strings is empty, nothing is printed. Returns true if
-the verbose flag is set. Otherwise returns undef.
+set. If the list of strings is empty, nothing is printed. Returns the filehandle
+that the verbose flag is set to. If the verbose flag is unset, returns undef.
 
 =head3 set_verbose
 
@@ -87,9 +87,9 @@ sub set_verbose {
 sub verbose {
     if ( defined $VERBOSE ) {
         print $VERBOSE @_ if @_;
-        return 1;
+        return $VERBOSE;
     } else {
-        return 0;
+        return;
     }
 }
 

--- a/t/utilities.t
+++ b/t/utilities.t
@@ -36,8 +36,8 @@ my $test_count = 1;
 # Test verbose function
 {
     # Test caller and setter when not set
-    is verbose("foo"), 0;     
-    is verbose("bar", "bin"), 0;
+    is verbose("foo"), undef;     
+    is verbose("bar", "bin"), undef;
     is set_verbose(), undef;
     is set_verbose({}), undef;
     is set_verbose([]), undef;
@@ -51,16 +51,16 @@ my $test_count = 1;
         local *STDERR;
         open(STDERR, ">", \$stderr);
         is set_verbose(1), \*STDERR;
-        is verbose("foo"), 1;
-        is verbose("bar", "bin"), 1;
-        is verbose(), 1;
+        is verbose("foo"), \*STDERR;
+        is verbose("bar", "bin"), \*STDERR;
+        is verbose(), \*STDERR;
         is $stderr, "foobarbin";
         $test_count += 5;
         close(STDERR);
     }
     # Now test unsetting
     is set_verbose(undef), undef;
-    is verbose(), 0;
+    is verbose(), undef;
     $test_count += 2; 
 }
 


### PR DESCRIPTION
The verbose option works, but there are certain messages I believe that should be printed regardless.  If I use the print function for these messages, along with the --verbose option for the extra messages, then the output doesn't get printed in the proper order.

I'm not sure what decision was made with the output for verbose, but for me to ensure that the output occurs in the right order, I have to flush the buffer (`$|=1`) which I don't think is the right way to do it.  There isn't a `utilities::message()` function, but is there a way of ensuring that the output, regardless of which function is used (print, error, warning, verbose) comes out in the right order?
