### PR TITLE
Reserved Proton ID?

### DIFF
--- a/lib/ModelSEED/MS/Biochemistry.pm
+++ b/lib/ModelSEED/MS/Biochemistry.pm
@@ -14,12 +14,40 @@ use ModelSEED::utilities qw ( args verbose );
 use ModelSEED::Configuration;
 use namespace::autoclean;
 extends 'ModelSEED::MS::DB::Biochemistry';
-#***********************************************************************************************************
-# ADDITIONAL ATTRIBUTES:
-#***********************************************************************************************************
-has definition => ( is => 'rw', isa => 'Str',printOrder => '-1', type => 'msdata', metaclass => 'Typed', lazy => 1, builder => '_builddefinition' );
-has dataDirectory => ( is => 'rw', isa => 'Str',printOrder => '-1', type => 'msdata', metaclass => 'Typed', lazy => 1, builder => '_builddataDirectory' );
-has reactionRoleHash => ( is => 'rw', isa => 'HashRef',printOrder => '-1', type => 'msdata', metaclass => 'Typed', lazy => 1, builder => '_buildreactionRoleHash' );
+
+has definition => (
+    is         => 'rw',
+    isa        => 'Str',
+    printOrder => '-1',
+    type       => 'msdata',
+    metaclass  => 'Typed',
+    lazy       => 1,
+    builder    => '_builddefinition'
+);
+has dataDirectory => (
+    is         => 'rw',
+    isa        => 'Str',
+    printOrder => '-1',
+    type       => 'msdata',
+    metaclass  => 'Typed',
+    lazy       => 1,
+    builder    => '_builddataDirectory'
+);
+has reactionRoleHash => (
+    is         => 'rw',
+    isa        => 'HashRef',
+    printOrder => '-1',
+    type       => 'msdata',
+    metaclass  => 'Typed',
+    lazy       => 1,
+    builder    => '_buildreactionRoleHash'
+);
+has proton => (
+    is         => 'rw',
+    isa        => 'Maybe[ModelSEED::MS::Compound]',
+    lazy       => 1,
+    builder    => '_build_proton',
+);
 
 #***********************************************************************************************************
 # BUILDERS:
@@ -52,6 +80,19 @@ sub _buildreactionRoleHash {
 		}
 	}
 	return $hash;
+}
+sub _build_proton {
+    my $self = shift;
+    my $compounds = $self->compounds;
+    my $proton;
+    # Find proton based on formula eq 'H'
+    foreach my $cpd (@$compounds) {
+        if ($cpd->formula eq 'H') {
+            $proton = $cpd;
+            last;
+        }
+    }
+    return $proton;
 }
 
 =head3 printDBFiles


### PR DESCRIPTION
I know this goes against the whole point of UUIDs, but protons are a special case.  Consider this code from MS::Reaction::createEquation():

```
        for (my $i=0; $i < @{$rgt}; $i++) {
                my $id = $rgt->[$i]->compound_uuid();
                if ($args->{format} eq "name" || $args->{format} eq "id") {
                        my $function = $args->{format};
                        $id = $rgt->[$i]->compound()->$function();
                } elsif ($args->{format} ne "uuid") {
                        $id = $rgt->[$i]->compound()->getAlias($args->{format});
                }
                if (!defined($rgtHash->{$id}->{$rgt->[$i]->compartment()->id()})) {
                        $rgtHash->{$id}->{$rgt->[$i]->compartment()->id()} = 0;
                }
                $rgtHash->{$id}->{$rgt->[$i]->compartment()->id()} += $rgt->[$i]->coefficient();
        }
```

For reaction matching, I have to exclude protons which have already been listed as a reagent.  I can't use the compound's uuid to say `next if $rgt->[$i]->compound_uuid() eq $proton_uuid` for my specific case, simply because the proton's uuid is going to be different for every biochemistry.

Because we're using KEGG and MetaCyc, we can safely use actual well-known names/identifiers such as "H+" but if anyone is attempting to merge their own local biochemistries, I can make no guarantee that the code would recognize protons and properly match reactions, thoughts?

It crossed my mind that we could check the biochemistry, before saving it, for known identifiers/names such as "H+" etc and then inform the user that we're assuming this is the proton.
