### PR TITLE
Add problemreport.txt to output file hash

### DIFF
--- a/lib/ModelSEED/MS/GapfillingFormulation.pm
+++ b/lib/ModelSEED/MS/GapfillingFormulation.pm
@@ -350,6 +350,7 @@ sub prepareFBAFormulation {
 		$form->inputfiles()->{"InactiveModelReactions.txt"}->[0] = "bio1";
 	}
 	push(@{$form->outputfiles}, "CompleteGapfillingOutput.txt");
+	push(@{$form->outputfiles}, "ProblemReport.txt");
 	if ($self->biomassHypothesis() == 1) {
 		$form->parameters()->{"Biomass modification hypothesis"} = 1;
 		$self->addBiomassComponentReactions();


### PR DESCRIPTION
We need ProblemReport.txt in the FBA output for gapfill in order to compare the objectives for multiple solutions and check their equivalency. This patch adds it in the logical place.
