### PR TITLE
Fix handling of commented code

### DIFF
--- a/lib/ModelSEED/MS/Utilities/GlobalFunctions.pm
+++ b/lib/ModelSEED/MS/Utilities/GlobalFunctions.pm
@@ -55,6 +55,7 @@ sub functionToRoles {
 	};
 	my $array = [split(/\#/,$function)];
 	$function = shift(@{$array});
+	$function =~ s/\s+$//;
 	$output->{comment} = join("#",@{$array});
 	if (length($output->{comment}) > 0) {
 		foreach my $comp (keys(%{$compartmentTranslation})) {


### PR DESCRIPTION
In order for the role to match correctly with a role in the mapping object we need to strip spaces between the role's name and the beginning of the comment.
