### PR TITLE
Iterative integration fix

### DIFF
--- a/lib/ModelSEED/MS/GapfillingFormulation.pm
+++ b/lib/ModelSEED/MS/GapfillingFormulation.pm
@@ -486,7 +486,9 @@ sub createSolutionsFromArray {
 	my $mdl = $args->{model};
 	my $bio = $mdl->biochemistry();
 	for (my $i=0; $i < @{$data}; $i++) {
-		if ($data->[$i] =~ m/^bio/) {
+	    # If more than one reaction is used as a target we need to use the line (the last line I presume) that
+	    # contains all the solutions.
+	    if ( $i == @{$data} ) {
 			my $array = [split(/\t/,$data->[$i])];
 			if (defined($array->[1])) {
 				my $solutionsArray = [split(/\|/,$array->[1])];

--- a/lib/ModelSEED/MS/GapfillingFormulation.pm
+++ b/lib/ModelSEED/MS/GapfillingFormulation.pm
@@ -488,7 +488,7 @@ sub createSolutionsFromArray {
 	for (my $i=0; $i < @{$data}; $i++) {
 	    # If more than one reaction is used as a target we need to use the line (the last line I presume) that
 	    # contains all the solutions.
-	    if ( $i == @{$data} ) {
+	    if ( $i == @{$data} - 1 ) {
 			my $array = [split(/\t/,$data->[$i])];
 			if (defined($array->[1])) {
 				my $solutionsArray = [split(/\|/,$array->[1])];


### PR DESCRIPTION
This fix allows us to integrate each solution activating one or more reactions from iterative gapfilling as a separate solution. Later we might want to consider some way of lumping them together to separate this case from the case in which we ask for multiple solutions to gapfilling a single reaction.
